### PR TITLE
Pipeline fix

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -37,9 +37,10 @@ phases:
         --s3-bucket $TEMPLATE_BUCKET --s3-prefix kafka --force-upload
         --output-template-file master.yaml
       - |
-        TEMPLATES=$(aws s3api list-objects --bucket $TEMPLATE_BUCKET --prefix kafka/ | jq .Contents[].Key)
+        TEMPLATES=$(aws s3api list-objects-v2 --start-after kafka/ --bucket $TEMPLATE_BUCKET --prefix kafka/ | jq -r .Contents[].Key)
         for template in ${TEMPLATES}; do
-        	aws s3api put-object-acl --bucket $TEMPLATE_BUCKET --key ${template} --acl bucket-owner-full-control
+          echo ${template}
+          aws s3api put-object-acl --bucket ${TEMPLATE_BUCKET} --key ${template} --acl bucket-owner-full-control
         done
 
 artifacts:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -36,6 +36,11 @@ phases:
       - aws cloudformation package --template-file master-template.yaml
         --s3-bucket $TEMPLATE_BUCKET --s3-prefix kafka --force-upload
         --output-template-file master.yaml
+      - |
+        TEMPLATES=$(aws s3 list-objects --bucket $TEMPLATE_BUCKET --prefix kafka/ | jq .Contents[].Key)
+        for template in ${TEMPLATES}; do
+        	aws s3api put-object-acl --bucket $TEMPLATE_BUCKET --key $template --acl bucket-owner-full-control
+        done
 
 artifacts:
   files:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -39,7 +39,7 @@ phases:
       - |
         TEMPLATES=$(aws s3api list-objects --bucket $TEMPLATE_BUCKET --prefix kafka/ | jq .Contents[].Key)
         for template in ${TEMPLATES}; do
-        	aws s3api put-object-acl --bucket $TEMPLATE_BUCKET --key $template --acl bucket-owner-full-control
+        	aws s3api put-object-acl --bucket $TEMPLATE_BUCKET --key ${template} --acl bucket-owner-full-control
         done
 
 artifacts:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -37,7 +37,7 @@ phases:
         --s3-bucket $TEMPLATE_BUCKET --s3-prefix kafka --force-upload
         --output-template-file master.yaml
       - |
-        TEMPLATES=$(aws s3 list-objects --bucket $TEMPLATE_BUCKET --prefix kafka/ | jq .Contents[].Key)
+        TEMPLATES=$(aws s3api list-objects --bucket $TEMPLATE_BUCKET --prefix kafka/ | jq .Contents[].Key)
         for template in ${TEMPLATES}; do
         	aws s3api put-object-acl --bucket $TEMPLATE_BUCKET --key $template --acl bucket-owner-full-control
         done


### PR DESCRIPTION
A last minute bucket change that I made wasn't properly tested - objects uploaded were not accesible by the bucket owner causing the prod pipeline to fail. This should fix the object ACL's so that the bucket policies apply correctly.