### PR TITLE
Update Kafka Dashboard and Fix Prometheus Queries

### DIFF
--- a/prometheus/dashboards/kafka-ecs-grafana-5.0.x.json
+++ b/prometheus/dashboards/kafka-ecs-grafana-5.0.x.json
@@ -65,7 +65,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1522962644641,
+  "iteration": 1523388248913,
   "links": [],
   "panels": [
     {
@@ -858,7 +858,7 @@
       "fill": 0,
       "gridPos": {
         "h": 6,
-        "w": 11,
+        "w": 5,
         "x": 2,
         "y": 21
       },
@@ -939,8 +939,8 @@
       "fill": 0,
       "gridPos": {
         "h": 6,
-        "w": 11,
-        "x": 13,
+        "w": 5,
+        "x": 7,
         "y": 21
       },
       "id": 61,
@@ -979,6 +979,168 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Offline Partitions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      },
+      "id": 81,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kafka_controller_ControllerStats_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"LeaderElectionRateAndTimeMs\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Leader Election Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "id": 82,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kafka_controller_ControllerStats_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"UncleanLeaderElectionsPerSec\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unclean Leader Election Rate (per second)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1653,5 +1815,5 @@
   },
   "timezone": "",
   "title": "Kafka ECS",
-  "version": 25
+  "version": 30
 }

--- a/prometheus/dashboards/kafka-ecs-grafana-5.0.x.json
+++ b/prometheus/dashboards/kafka-ecs-grafana-5.0.x.json
@@ -65,7 +65,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1523388248913,
+  "iteration": 1523390806052,
   "links": [],
   "panels": [
     {
@@ -118,7 +118,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",topic=~\"$topic\",name=\"MessagesInPerSec\"}) by (topic)",
+          "expr": "sum without(instance)(rate(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",topic=~\"$topic\",name=\"MessagesInPerSec\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -199,7 +199,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",name=\"MessagesInPerSec\"}) by (instance)",
+          "expr": "sum without(topic)(rate(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",name=\"MessagesInPerSec\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -293,7 +293,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",topic=~\"$topic\",name=\"BytesInPerSec\"}) by (topic)",
+          "expr": "sum without(instance)(rate(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",topic=~\"$topic\",name=\"BytesInPerSec\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -374,7 +374,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",topic=~\"$topic\",name=\"FailedFetchRequestsPerSec\"}) by (topic)",
+          "expr": "sum without(instance)(rate(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",topic=~\"$topic\",name=\"FailedFetchRequestsPerSec\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -549,7 +549,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",name=\"BytesInPerSec\"}) by (instance)",
+          "expr": "sum without(topic)(rate(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",name=\"BytesInPerSec\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -630,7 +630,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",name=\"FailedFetchRequestsPerSec\"}) by (instance)",
+          "expr": "sum without(topic)(rate(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",topic=~\"$topic\",name=\"FailedFetchRequestsPerSec\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -711,7 +711,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",name=\"BytesOutPerSec\"}) by (instance)",
+          "expr": "sum without(topic)(rate(kafka_server_BrokerTopicMetrics_Count{job=\"$prometheus_job_name\",instance=~\"$instance\",name=\"BytesOutPerSec\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1048,7 +1048,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kafka_controller_ControllerStats_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"LeaderElectionRateAndTimeMs\"}",
+          "expr": "rate(kafka_controller_ControllerStats_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"LeaderElectionRateAndTimeMs\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1283,7 +1283,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kafka_server_ReplicaManager_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"IsrShrinksPerSec\"}",
+          "expr": "rate(kafka_server_ReplicaManager_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"IsrShrinksPerSec\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1364,7 +1364,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kafka_server_ReplicaManager_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"IsrExpandsPerSec\"}",
+          "expr": "rate(kafka_server_ReplicaManager_Count{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"IsrExpandsPerSec\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1815,5 +1815,5 @@
   },
   "timezone": "",
   "title": "Kafka ECS",
-  "version": 30
+  "version": 35
 }

--- a/prometheus/dashboards/kafka-ecs-grafana-5.0.x.json
+++ b/prometheus/dashboards/kafka-ecs-grafana-5.0.x.json
@@ -65,7 +65,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1523390806052,
+  "iteration": 1523391738781,
   "links": [],
   "panels": [
     {
@@ -829,10 +829,10 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(kafka_controller_KafkaController_Value{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"ActiveControllerCount\"})",
+          "expr": "sum(kafka_controller_KafkaController_Value{job=\"$prometheus_job_name\", instance=~\"$instance\", name=\"ActiveControllerCount\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -1815,5 +1815,5 @@
   },
   "timezone": "",
   "title": "Kafka ECS",
-  "version": 35
+  "version": 37
 }


### PR DESCRIPTION
#### Description

Added the following metrics to the dashboard:
- Leader election rate
  - kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs
  - Non-zero when there are broker failures
- Unclean leader election rate
  - kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec
  - Zero when everything is normal

Also fixed Prometheus Queries to show the message throughput more accurately.

#### Test

Take a look at https://dev-grafana-us.datahub.loyalty.com/d/krpRqtiik/kafka-ecs

When running the producer performance script and consuming, the graphs now show the proper rates for the messages and throughput (5000 records/s | 5 MB/s). See screenshots below.

```
[ec2-user@ip-10-0-1-238 confluent-4.0.0]$ bin/kafka-producer-perf-test --producer-props bootstrap.servers=$brokers --topic test --num-records 1000000 --record-size 1024 --throughput 5000
24906 records sent, 4980.2 records/sec (4.86 MB/sec), 31.1 ms avg latency, 167.0 max latency.
24989 records sent, 4997.8 records/sec (4.88 MB/sec), 23.6 ms avg latency, 132.0 max latency.
25037 records sent, 5004.4 records/sec (4.89 MB/sec), 21.1 ms avg latency, 75.0 max latency.
25005 records sent, 4993.0 records/sec (4.88 MB/sec), 20.3 ms avg latency, 143.0 max latency.
25040 records sent, 5006.0 records/sec (4.89 MB/sec), 19.6 ms avg latency, 93.0 max latency.
25023 records sent, 5003.6 records/sec (4.89 MB/sec), 36.5 ms avg latency, 349.0 max latency.
24392 records sent, 4872.6 records/sec (4.76 MB/sec), 48.5 ms avg latency, 838.0 max latency.
25641 records sent, 5128.2 records/sec (5.01 MB/sec), 59.0 ms avg latency, 747.0 max latency.
25013 records sent, 5001.6 records/sec (4.88 MB/sec), 17.5 ms avg latency, 93.0 max latency.
24979 records sent, 4993.8 records/sec (4.88 MB/sec), 23.0 ms avg latency, 120.0 max latency.
25014 records sent, 4999.8 records/sec (4.88 MB/sec), 21.2 ms avg latency, 220.0 max latency.
24999 records sent, 4994.8 records/sec (4.88 MB/sec), 21.8 ms avg latency, 127.0 max latency.
24973 records sent, 4994.6 records/sec (4.88 MB/sec), 24.9 ms avg latency, 246.0 max latency.
24233 records sent, 4846.6 records/sec (4.73 MB/sec), 71.0 ms avg latency, 727.0 max latency.
25865 records sent, 5167.8 records/sec (5.05 MB/sec), 73.8 ms avg latency, 690.0 max latency.
24928 records sent, 4984.6 records/sec (4.87 MB/sec), 17.7 ms avg latency, 113.0 max latency.
25076 records sent, 5015.2 records/sec (4.90 MB/sec), 18.3 ms avg latency, 63.0 max latency.
24982 records sent, 4995.4 records/sec (4.88 MB/sec), 31.9 ms avg latency, 252.0 max latency.
24924 records sent, 4983.8 records/sec (4.87 MB/sec), 20.5 ms avg latency, 63.0 max latency.
24841 records sent, 4965.2 records/sec (4.85 MB/sec), 145.8 ms avg latency, 686.0 max latency.
24283 records sent, 4852.7 records/sec (4.74 MB/sec), 139.0 ms avg latency, 723.0 max latency.
24522 records sent, 4903.4 records/sec (4.79 MB/sec), 181.0 ms avg latency, 941.0 max latency.
23048 records sent, 4608.7 records/sec (4.50 MB/sec), 461.2 ms avg latency, 2074.0 max latency.
24234 records sent, 4845.8 records/sec (4.73 MB/sec), 742.5 ms avg latency, 2525.0 max latency.
24308 records sent, 4861.6 records/sec (4.75 MB/sec), 878.5 ms avg latency, 2972.0 max latency.
23711 records sent, 4741.3 records/sec (4.63 MB/sec), 1068.1 ms avg latency, 3766.0 max latency.
26951 records sent, 5389.1 records/sec (5.26 MB/sec), 1359.6 ms avg latency, 4157.0 max latency.
4753 records sent, 633.1 records/sec (0.62 MB/sec), 822.7 ms avg latency, 9193.0 max latency.
56574 records sent, 11308.0 records/sec (11.04 MB/sec), 3515.3 ms avg latency, 9197.0 max latency.
28255 records sent, 5649.9 records/sec (5.52 MB/sec), 980.9 ms avg latency, 3263.0 max latency.
24830 records sent, 4962.0 records/sec (4.85 MB/sec), 395.2 ms avg latency, 1439.0 max latency.
23811 records sent, 4760.3 records/sec (4.65 MB/sec), 611.3 ms avg latency, 2159.0 max latency.
26332 records sent, 5258.0 records/sec (5.13 MB/sec), 753.7 ms avg latency, 2667.0 max latency.
24112 records sent, 4822.4 records/sec (4.71 MB/sec), 534.4 ms avg latency, 1972.0 max latency.
24908 records sent, 4981.6 records/sec (4.86 MB/sec), 729.9 ms avg latency, 2360.0 max latency.
26015 records sent, 5194.7 records/sec (5.07 MB/sec), 520.3 ms avg latency, 2061.0 max latency.
22980 records sent, 4596.0 records/sec (4.49 MB/sec), 547.0 ms avg latency, 2655.0 max latency.
22904 records sent, 4574.4 records/sec (4.47 MB/sec), 984.1 ms avg latency, 3734.0 max latency.
26189 records sent, 5234.7 records/sec (5.11 MB/sec), 1413.6 ms avg latency, 4432.0 max latency.
1000000 records sent, 4957.833625 records/sec (4.84 MB/sec), 551.21 ms avg latency, 9197.00 ms max latency, 27 ms 50th, 3599 ms 95th, 6171 ms 99th, 8618 ms 99.9th.
```

#### Screenshots

![image](https://user-images.githubusercontent.com/19393946/38585364-917fb4c2-3ce7-11e8-860d-e96a57adc580.png)
![image](https://user-images.githubusercontent.com/19393946/38585387-ab9015fa-3ce7-11e8-892b-5f9d9413636a.png)
![image](https://user-images.githubusercontent.com/19393946/38585400-bc29d090-3ce7-11e8-9fcf-7fd81fe72a30.png)
