### PR TITLE
Switch KAFKA_JMX_HOSTNAME to localhost for the sidecar

### DIFF
--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -79,7 +79,7 @@ Resources:
           - Name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
             Value: 2
           - Name: KAFKA_JMX_HOSTNAME
-            Value: !Sub '${BrokerName}${BrokerId}.${DomainName}'
+            Value: 'localhost'
           - Name: KAFKA_JMX_PORT
             Value: !Ref 'JMXPort'
           - Name: KAFKA_LOG4J_LOGGERS

--- a/zookeeper/service.yaml
+++ b/zookeeper/service.yaml
@@ -91,7 +91,7 @@ Resources:
           - Name: ZOOKEEPER_SYNC_LIMIT
             Value: 2
           - Name: KAFKA_JMX_HOSTNAME
-            Value: !Sub '${ServerName}.${DomainName}'
+            Value: 'localhost'
           - Name: KAFKA_JMX_PORT
             Value: !Ref 'JMXPort'
         PortMappings:


### PR DESCRIPTION
Instead of having jmxtrans reach out via the dns, it should always use localhost.

- No longer relying on dns resolution via route53/service discovery
- No longer routing traffic outside of local docker network between both containers