### PR TITLE
Use persistent EBS Data Volumes for Zookeeper and Brokers

### DIFF
--- a/ebs.yaml
+++ b/ebs.yaml
@@ -1,7 +1,7 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 
-Description: Creates an EBS volumes
+Description: Creates a EBS volume with predefined tags that can be used to attach to ECS cluster for data
 
 Parameters:
   DataVolumeSize:
@@ -41,9 +41,10 @@ Parameters:
   VolumeNameTag:
     Type: String
     Description: Tag for identifying the component the volume should be tagged with
-  BrokerId:
+  NodeId:
     Type: String
-    Description: Tag for identifying the broker id the volume belongs to
+    Description: Tag for identifying the node for the volume
+
 Conditions:
   UseIO1DataVolume: !Equals [!Ref DataVolumeType, 'io1']
 
@@ -67,5 +68,5 @@ Resources:
           Value: !Ref 'Environment'
         - Key: Component
           Value: ebs
-        - Key: BrokerId
-          Value: !Ref BrokerId
+        - Key: NodeId
+          Value: !Ref NodeId

--- a/ebs.yaml
+++ b/ebs.yaml
@@ -1,0 +1,66 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: Creates an EBS volumes
+
+Parameters:
+  DataVolumeSize:
+    Description: Data volume size in GB for ECS instances. These will be exposed via EBSMountPath to containers.
+    Type: Number
+    MinValue: 25
+    MaxValue: 2000
+    Default: 100
+    ConstraintDescription: Must be a value between 25 and 1000
+  DataVolumeType:
+    Type: String
+    Default: gp2
+    Description: The data volume type
+    AllowedValues: [gp2, io1, standard]
+    ConstraintDescription: Must be a valid volume type
+  DataVolumeIOPS:
+    Type: String
+    AllowedPattern: '[0-9]*'
+    Description: For 'io1' data volumes, select number of IOPS.
+    ConstraintDescription: Must be a valid IOPS value or empty
+  AvailabilityZone:
+    Type: String
+    Description: The availability zone in which to create the EBS volume
+  Project:
+    Description: Project tag
+    Type: String
+    MinLength: 1
+  Team:
+    Description: Team tag
+    Type: String
+    MinLength: 1
+  Environment:
+    Description: Environment (dev|sandbox|prod)
+    Type: String
+    AllowedValues: ['dev','sandbox','prod']
+    Default: dev
+  VolumeNameTag:
+    Type: String
+    Description: Tag for identifying the component the volume should be tagged with
+Conditions:
+  UseIO1DataVolume: !Equals [!Ref DataVolumeType, 'io1']
+
+Resources:
+  DataVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      Size: !Ref DataVolumeSize
+      VolumeType: !Ref DataVolumeType
+      Iops: !If [UseIO1DataVolume, !Ref DataVolumeIOPS, '']
+      AvailabilityZone: !Ref AvailabilityZone
+      Encrypted: true
+      Tags:
+        - Key: Name
+          Value: !Ref 'VolumeNameTag'
+        - Key: Project
+          Value: !Ref 'Project'
+        - Key: Team
+          Value: !Ref 'Team'
+        - Key: Environment
+          Value: !Ref 'Environment'
+        - Key: Component
+          Value: ebs

--- a/ebs.yaml
+++ b/ebs.yaml
@@ -41,6 +41,9 @@ Parameters:
   VolumeNameTag:
     Type: String
     Description: Tag for identifying the component the volume should be tagged with
+  BrokerId:
+    Type: String
+    Description: Tag for identifying the broker id the volume belongs to
 Conditions:
   UseIO1DataVolume: !Equals [!Ref DataVolumeType, 'io1']
 
@@ -64,3 +67,5 @@ Resources:
           Value: !Ref 'Environment'
         - Key: Component
           Value: ebs
+        - Key: BrokerId
+          Value: !Ref BrokerId

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -112,19 +112,19 @@ Parameters:
 Mappings:
   # These are the latest ECS optimized AMIs as of March 2018:
   #
-  #   amzn-ami-2017.09.j-amazon-ecs-optimized
-  #   ECS agent:    1.17.2
-  #   Docker:       17.12.0-ce
-  #   ecs-init:     1.17.2-1
+  #   amzn-ami-2017.09.l-amazon-ecs-optimized
+  #   ECS agent:    1.17.3
+  #   Docker:       17.12.1-ce
+  #   ecs-init:     1.17.3-1
   #
   # You can find the latest available on this page of our documentation:
   # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
   # (note the AMI identifier is region specific)
   AWSRegionToAMI:
     us-east-1:
-      AMI: ami-cad827b7
+      AMI: ami-aff65ad2
     ca-central-1:
-      AMI: ami-db48cfbf
+      AMI: ami-897ff9ed
 
 Resources:
   ECSLogGroup:

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -58,8 +58,10 @@ Parameters:
   ASGEventsTopic:
     Description: SNS topic to notify of ASG events
     Type: String
-  MinInstancesPerAsg:
-    Description: Minimum number of ECS instances. This controls how we can add more capacity.
+  MaxInstancesPerAsg:
+    Description: >
+      Maximum number of ECS instances. This controls how we can add more capacity and should be 1 more
+      than intended maximum so there is room to do rolling deployment.
     Type: Number
     Default: 2
     MinValue: 2
@@ -67,14 +69,6 @@ Parameters:
     ConstraintDescription: Must be a number between 2 and 5.
 
   # Features
-  ClusterType:
-    Type: String
-    Description: This will configure the ECS cluster for either running servics or kafka
-    AllowedValues: [service,kafka]
-    Default: service
-    ConstraintDescription: |
-      Must be either 'service' (schema registry, kafka connect, rest proxy, prometheus, etc)
-      or 'kafka' (zookeeper and brokers)
   HostedZoneId:
     Description: The ID of the Hosted Zone in which to register services for service discovery
     Type: String
@@ -131,9 +125,6 @@ Mappings:
       AMI: ami-cad827b7
     ca-central-1:
       AMI: ami-db48cfbf
-
-Conditions:
-  IsClusterTypeService: !Equals [!Ref 'ClusterType', 'service']
 
 Resources:
   ECSLogGroup:
@@ -241,21 +232,6 @@ Resources:
       Roles:
         - !Ref 'ECSInstanceRole'
 
-  EcsServiceRole:
-    Condition: IsClusterTypeService
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Sid: ''
-          Effect: Allow
-          Principal:
-            Service: ecs.amazonaws.com
-          Action: sts:AssumeRole
-      Path: /
-      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole']
-
   ECSSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -280,16 +256,6 @@ Resources:
       SecurityGroupEgress:
         IpProtocol: -1
         CidrIp: "0.0.0.0/0"
-
-  ECSELBSecurityGroupIngress:
-    Condition: IsClusterTypeService
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !GetAtt ECSSecurityGroup.GroupId
-      IpProtocol: tcp
-      FromPort: '32768'
-      ToPort: '65535'
-      SourceSecurityGroupId: !Ref 'ELBSecurityGroupId'
 
   ECSLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -319,11 +285,6 @@ Resources:
           echo "Initializing Instance"
           config_set="general"
 
-          if [ "${ClusterType}" == "service" ]; then
-            echo "Enabling docker-mirror..."
-            config_set="services"
-          fi
-
           /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration --configsets $config_set
           exit_code=$?
 
@@ -344,9 +305,6 @@ Resources:
             - install_ecs_instance
             - install_monitoring
             - install_service_discovery
-          services:
-            - ConfigSet: general
-            - install_docker_mirror
 
         # Configure and install aws logs agent
         install_logging:
@@ -435,12 +393,6 @@ Resources:
                 file = /var/log/service-discovery.log
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/service-discovery.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/docker-mirror.log]
-                file = /var/log/docker-mirror.log
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/docker-mirror.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
             '/etc/init/awslogs.conf':
               content: |
@@ -643,59 +595,6 @@ Resources:
                     --log-opt tag='{{.Name}}/{{.ID}}' \
                     $docker_image --hostedZoneId=${HostedZoneId}
                 end script
-        install_docker_mirror:
-          files:
-            '/etc/init/docker_mirror.conf':
-              mode: '000644'
-              owner: root
-              group: root
-              content: |
-                #upstart-job
-                description "Retrieve instances's private ip to store in /etc/hostip and start docker mirror container"
-                author "LoyaltyOne"
-                start on started ecs
-
-                script
-                  exec >> /var/log/docker-mirror.log 2>&1
-                  set -e
-                  set -x
-
-                  until curl -s http://169.254.169.254/latest/meta-data
-                  do
-                      sleep 1
-                  done
-
-                  # Grab the ip of this instance
-                  ip=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
-                  echo $ip > /etc/hostip
-
-                  # Pull docker image. Try up to 3 times before giving up.
-                  docker_image=loyaltyone/docker-mirror:0.1.2
-                  count=3
-                  while [[ $count -gt 0 ]]; do
-                    echo "Fetching docker image '$docker_image'..."
-                    docker pull $docker_image
-                    if [[ "$?" -gt 0 ]]; then
-                      count=$(($count - 1))
-                      echo "Problem fetching docker image '$docker_image'."
-                      echo "Taking a nap for 5 seconds..."
-                      sleep 5
-                    else
-                      echo "Fetched docker image for '$docker_image'."
-                      count=0
-                    fi
-                  done
-
-                  # Start docker mirror
-                  echo "Starting docker mirror..."
-                  docker run -d \
-                    --name docker-mirror \
-                    -p 9001:9000 \
-                    --restart always \
-                    -v /var/run/docker.sock:/var/run/docker.sock \
-                    -v /etc/hostip:/etc/hostip \
-                    $docker_image
-                end script
         install_monitoring:
           packages:
             yum:
@@ -740,7 +639,7 @@ Resources:
       VPCZoneIdentifier: [!Select [0, !Ref 'Subnets']]
       LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
       MinSize: 1
-      MaxSize: !Ref 'MinInstancesPerAsg'
+      MaxSize: !Ref 'MaxInstancesPerAsg'
       DesiredCapacity: 1
       NotificationConfigurations:
         - TopicARN: !Ref 'ASGEventsTopic'
@@ -790,7 +689,7 @@ Resources:
       VPCZoneIdentifier: [!Select [1, !Ref 'Subnets']]
       LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
       MinSize: 1
-      MaxSize: !Ref 'MinInstancesPerAsg'
+      MaxSize: !Ref 'MaxInstancesPerAsg'
       DesiredCapacity: 1
       NotificationConfigurations:
         - TopicARN: !Ref 'ASGEventsTopic'
@@ -840,7 +739,7 @@ Resources:
       VPCZoneIdentifier: [!Select [2, !Ref 'Subnets']]
       LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
       MinSize: 1
-      MaxSize: !Ref 'MinInstancesPerAsg'
+      MaxSize: !Ref 'MaxInstancesPerAsg'
       DesiredCapacity: 1
       NotificationConfigurations:
         - TopicARN: !Ref 'ASGEventsTopic'
@@ -925,60 +824,6 @@ Resources:
       DefaultResult: 'ABANDON'
       HeartbeatTimeout: '300'
 
-  # unused but exported by
-  # awslabs/ecs-refarch-cloudformation/master/infrastructure/ecs-cluster.yaml
-  ECSServiceAutoScalingRole:
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          Action: 'sts:AssumeRole'
-          Effect: Allow
-          Principal:
-            Service: application-autoscaling.amazonaws.com
-      Policies:
-      - PolicyName: ecs-service-autoscaling
-        PolicyDocument:
-          Statement:
-            Action:
-            - application-autoscaling:DeleteScalingPolicy
-            - application-autoscaling:DeleteScheduledAction
-            - application-autoscaling:DeregisterScalableTarget
-            - application-autoscaling:DescribeScalableTargets
-            - application-autoscaling:DescribeScalingActivities
-            - application-autoscaling:DescribeScalingPolicies
-            - application-autoscaling:DescribeScheduledActions
-            - application-autoscaling:PutScalingPolicy
-            - application-autoscaling:PutScheduledAction
-            - application-autoscaling:RegisterScalableTarget
-            - cloudwatch:DescribeAlarms
-            - cloudwatch:PutMetricAlarm
-            - ecs:DescribeServices
-            - ecs:UpdateService
-            Effect: Allow
-            Resource: '*'
-
-  # unused but exported by, not sure if we need this since we don't use LBs?
-  # LoyaltyOne/apollo-platform/blob/master/common/ecs/Cluster-with-ALB-CPU-Scaling.yml
-  # The Amazon ECS service scheduler makes calls to the Amazon EC2 and Elastic Load Balancing APIs on your behalf
-  # to register and deregister container instances with your load balancers. Before you can attach a load balancer
-  # to an Amazon ECS service, you must create an IAM role for your services to use before you start them.
-  # This requirement applies to any Amazon ECS service that you plan to use with a load balancer.
-  EcsServiceSchedulerRole:
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Action: 'sts:AssumeRole'
-          Effect: Allow
-          Principal:
-            Service: ecs.amazonaws.com
-      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole']
-
 Outputs:
   AsgName0:
     Description: Name of first ASG created
@@ -992,22 +837,12 @@ Outputs:
   ClusterName:
     Description: A reference to the ECS cluster
     Value: !Ref 'ECSCluster'
-  ServiceAutoScalingRole:
-    Description: A reference to ECS service auto scaling role
-    Value: !GetAtt 'ECSServiceAutoScalingRole.Arn'
-  ServiceSchedulerRole:
-    Description: A reference to ECS service load balancing role
-    Value: !GetAtt 'EcsServiceSchedulerRole.Arn'
   InstanceSecurityGroup:
     Description: The ID of the ecs container instance security group created
     Value: !GetAtt [ECSSecurityGroup, GroupId]
   VpcId:
     Description: "Cluster's VPC Id"
     Value: !Ref 'VPCId'
-  ServiceRole:
-    Condition: IsClusterTypeService
-    Description: The ARN of the ECS service role
-    Value: !GetAtt [EcsServiceRole, Arn]
   EBSMountPath:
     Description: Path at which to create the mount for the EBS data volume
     Value: !Ref 'EBSMountPath'

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -2,8 +2,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
 Description: >
-  Creates an ECS cluster that expects data volumes for each ECS Instance to be precreated and tagged.
-  The cluster is spread across 3 availability zones with one autoscaling group per availability zone.
+  Creates an ECS cluster for core Kafka components, Zookeeper and Brokers. It expects data volumes for each ECS
+  Instance to be precreated and tagged. The cluster is spread across 3 availability zones with one autoscaling
+  group per availability zone.
 
 Parameters:
   # Networking

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -3,6 +3,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 
 Description: >
   Creates an ECS cluster that expects data volumes for each ECS Instance to be precreated and tagged.
+  The cluster is spread across 3 availability zones with one autoscaling group per availability zone.
 
 Parameters:
   # Networking

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -119,6 +119,13 @@ Parameters:
     AllowedValues: ['dev','sandbox','prod']
     Default: dev
 
+  ParentStackName:
+    Description: Name of parent stack
+    Type: String
+  VolumeNameTag:
+    Type: String
+    Description: Tag for identifying the component the volume should be tagged with
+
 Mappings:
   # These are the latest ECS optimized AMIs as of March 2018:
   #
@@ -216,7 +223,12 @@ Resources:
               'ssm:PutConfigurePackageResult',
               'ssm:UpdateAssociationStatus',
               'ssm:UpdateInstanceAssociationStatus',
-              'ssm:UpdateInstanceInformation'
+              'ssm:UpdateInstanceInformation',
+              'ec2:DescribeInstances',
+              'ec2:DescribeTags',
+              'ec2:CreateTags',
+              'ec2:DescribeVolumes',
+              'ec2:AttachVolume'
             ]
             Effect: Allow
             Resource: '*'
@@ -283,13 +295,6 @@ Resources:
     Properties:
       AssociatePublicIpAddress: false
       EbsOptimized: !Ref 'EBSOptimizedInstance'
-      BlockDeviceMappings:
-        - DeviceName: '/dev/xvdh'
-          Ebs:
-            VolumeSize: !Ref 'EBSVolumeSize'
-            DeleteOnTermination: 'true'
-            Encrypted: 'true'
-            VolumeType: 'gp2'
       IamInstanceProfile: !Ref 'ECSInstanceProfile'
       ImageId:  !FindInMap [AWSRegionToAMI, !Ref 'AWS::Region', AMI]
       InstanceType: !Ref 'InstanceType'
@@ -301,7 +306,7 @@ Resources:
         'Fn::Base64': !Sub |
           #!/bin/bash
 
-          exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+          exec 2>>/var/log/user-data.log
 
           # Increment RollingDeploymentVersion parameter to force rolling deploy
           version=${RollingDeploymentVersion}
@@ -321,8 +326,15 @@ Resources:
           /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration --configsets $config_set
           exit_code=$?
 
-          echo "Signalling ASG..."
-          /opt/aws/bin/cfn-signal -e $exit_code --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSAutoScalingGroup
+          if [ $exit_code == 0 ]; then
+            instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+
+            echo "Grabbing tag of autoscaling resource name with instance id='$instance_id'"
+            asgresourcename=$(aws ec2 describe-tags --region ${AWS::Region} --filters Name=resource-id,Values=$instance_id Name=tag-key,Values=AsgResourceName | jq -r '.Tags[0].Value')
+          fi
+
+          echo "Signalling ASG with resource name='$asgresourcename'"
+          /opt/aws/bin/cfn-signal -e $exit_code --region ${AWS::Region} --stack ${AWS::StackName} --resource $asgresourcename
     Metadata:
       AWS::CloudFormation::Init:
         configSets:
@@ -455,19 +467,94 @@ Resources:
               owner: root
               group: root
               content: !Sub |
-                #!/bin/bash -e
+                #!/bin/bash
 
-                exec > >(tee /var/log/user-data.log|logger -t setup-data-volume -s 2>/dev/console) 2>&1
+                exec 2>>/var/log/user-data.log
 
-                echo "Creating XFS file system on /dev/xvdh..."
-                mkfs.xfs -f /dev/xvdh
 
-                echo "Setting up mount point for data volume on ${EBSMountPath}..."
+                # Setup environment variables
+
+                export instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+                export az=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+                export AWS_DEFAULT_REGION=${AWS::Region}
+
+                #export asg_name=$(aws ec2 describe-tags --filters Name=resource-id,Values=$instance_id Name=tag-key,Values=AsgName | jq -r '.Tags[0].Value')
+
+                # This script will find next available volume in the instance's availability zone and attach it. It will
+                # initialize the file system if it is the first time it attaches; this is determined by existence of the
+                # InstanceId tag (initially it is not present). Finally it will mount the file system and add the
+                # InstanceId tag of current instance.
+
+                # Find a volume in the availability zone to attach with Name ${ParentStackName}-${VolumeNameTag}
+                status=
+                volume_id=
+                while [[ "$status" != "attached" ]]; do
+                  echo "Searching for available volumes in '$az'"
+                  ids=($(aws ec2 describe-volumes --filters Name=status,Values=available Name=availability-zone,Values=$az Name=tag-key,Values=Name Name=tag-value,Values=${ParentStackName}-${VolumeNameTag} | jq -r '.Volumes[].VolumeId'))
+
+                  if [[ ${!#ids[@]} -gt 0 ]]; then
+                    # Try first volume. If for some reason there is a race condition, next time around we try it should pick
+                    # a different available volume. Number of volumes match the ensemble and availability zones so unless
+                    # something really bad happened, this should succeed at most once.
+                    echo "Attaching volume id ${!ids[0]}..."
+                    status=$(aws ec2 attach-volume --device /dev/xvdh --instance-id $instance_id --volume-id ${!ids[0]} | jq -r '.State')
+
+                    if [[ -z $status ]]; then
+                      echo "Waiting for data volumes to become available..."
+                    elif [[ "$status" -eq "attaching" ]]; then
+                      while [[ "$status" != "attached" ]]; do
+                         echo "Waiting for data volume ${!ids[0]} to be attached..."
+                         status=$(aws ec2 describe-volumes --volume-id ${!ids[0]} | jq -r '.Volumes[0].Attachments[0].State')
+                         sleep 10
+                      done
+
+                      echo "Successfully attached data volume ${!ids[0]}"
+                      volume_id=${!ids[0]}
+                    elif [[ "$status" -eq "attached" ]]; then
+                      echo "Successfully attached data volume ${!ids[0]}"
+                      volume_id=${!ids[0]}
+                    else
+                      echo "Volume ${!ids[0]} status is '$status'. Waiting for volumes to become available..."
+                      sleep 10
+                    fi
+                  else
+                    echo "Waiting for volumes to become available..."
+                    sleep 10
+                  fi
+                done
+
+                # Check volume's tag to see if it belonged to another instance so we don't reformat it
+                attached_instance_id=$(aws ec2 describe-tags --filters Name=resource-id,Values=$volume_id Name=tag-key,Values=InstanceId | jq -r '.Tags[].Value')
+                if [[ -z $attached_instance_id ]]; then
+                  echo "First time attachment. Creating XFS file system..."
+                  mkfs.xfs -f /dev/xvdh
+                fi
+
+                # Setup and mount data volume
+                echo "Setting up mount point for data volume..."
                 mkdir -p ${EBSMountPath}
-                echo "/dev/xvdh  ${EBSMountPath}  xfs  defaults,inode64,nofail,context=system_u:object_r:var_t:s0  0 2" >> /etc/fstab
+                chown -R root:root /var/private
 
                 echo "Mounting file system..."
+                echo "/dev/xvdh  ${EBSMountPath}  xfs  defaults,inode64,nofail,context=system_u:object_r:var_t:s0  0 2" >> /etc/fstab
                 mount -v ${EBSMountPath}
+
+                # Add tag to the volume so we can identify ownership to the instance
+                echo "Setting up tag InstanceId=$instance_id for volume $volume_id..."
+                aws ec2 create-tags --resources $volume_id --tags Key=InstanceId,Value=$instance_id
+
+                # Get Broker Id from volume tag and transfer to instance
+                broker_id=$(aws ec2 describe-volumes --volume-ids $volume_id | jq -r '.Volumes[0].Tags[] | select(.Key == "BrokerId").Value')
+                echo "Setting up InstanceId=$instance_id for tag BrokerId=$broker_id..."
+                aws ec2 create-tags --resources $instance_id --tags Key=BrokerId,Value=$broker_id
+                echo $broker_id > /tmp/broker.id
+
+                # Get the Route53 recordset name
+                recordset_name=$(aws ec2 describe-volumes --volume-ids $volume_id | jq -r '.Volumes[0].Tags[] | select(.Key == "RecordSetName").Value')
+
+                # Add tag to the instance so we can identify the record set
+                echo "Setting up InstanceId=$instance_id for tag RecordSetName=$recordset_name..."
+                aws ec2 create-tags --resources $instance_id --tags Key=RecordSetName,Value=$recordset_name
           commands:
             01_setup_ebs_volume:
               command: '/usr/local/share/setup-data-volume'
@@ -621,15 +708,15 @@ Resources:
               mode: '000644'
               owner: root
               group: root
-  ECSAutoScalingGroup:
+  ECSAutoScalingGroup0:
     DependsOn: 'ECSLogGroup'
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      VPCZoneIdentifier: !Ref 'Subnets'
+      VPCZoneIdentifier: [!Select [0, !Ref 'Subnets']]
       LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
-      MinSize: !Ref 'ASGMinSize'
-      MaxSize: !Ref 'ASGMaxSize'
-      DesiredCapacity: !Ref 'ASGDesiredCapacity'
+      MinSize: 1
+      MaxSize: 1
+      DesiredCapacity: 1
       NotificationConfigurations:
         - TopicARN: !Ref 'ASGEventsTopic'
           NotificationTypes:
@@ -652,6 +739,109 @@ Resources:
           PropagateAtLaunch: true
         - Key: Scheduler
           Value: false
+          PropagateAtLaunch: true
+        - Key: AsgResourceName
+          Value: 'ECSAutoScalingGroup0'
+          PropagateAtLaunch: true
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT15M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: !Ref 'RollingUpdateMinInService'
+        MaxBatchSize: 1
+        PauseTime: PT15M
+        SuspendProcesses:
+          - HealthCheck
+          - ReplaceUnhealthy
+          - AZRebalance
+          - AlarmNotification
+          - ScheduledActions
+        WaitOnResourceSignals: true
+  ECSAutoScalingGroup1:
+    DependsOn: 'ECSLogGroup'
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      VPCZoneIdentifier: [!Select [1, !Ref 'Subnets']]
+      LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
+      MinSize: 1
+      MaxSize: 1
+      DesiredCapacity: 1
+      NotificationConfigurations:
+        - TopicARN: !Ref 'ASGEventsTopic'
+          NotificationTypes:
+          - autoscaling:EC2_INSTANCE_TERMINATE
+      Tags:
+        - Key: Name
+          Value: !Sub 'ECS Container Instance - ${AWS::StackName}'
+          PropagateAtLaunch: true
+        - Key: Project
+          Value: !Ref 'Project'
+          PropagateAtLaunch: true
+        - Key: Team
+          Value: !Ref 'Team'
+          PropagateAtLaunch: true
+        - Key: Environment
+          Value: !Ref 'Environment'
+          PropagateAtLaunch: true
+        - Key: Component
+          Value: ecs
+          PropagateAtLaunch: true
+        - Key: Scheduler
+          Value: false
+          PropagateAtLaunch: true
+        - Key: AsgResourceName
+          Value: 'ECSAutoScalingGroup1'
+          PropagateAtLaunch: true
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT15M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: !Ref 'RollingUpdateMinInService'
+        MaxBatchSize: 1
+        PauseTime: PT15M
+        SuspendProcesses:
+          - HealthCheck
+          - ReplaceUnhealthy
+          - AZRebalance
+          - AlarmNotification
+          - ScheduledActions
+        WaitOnResourceSignals: true
+  ECSAutoScalingGroup2:
+    DependsOn: 'ECSLogGroup'
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      VPCZoneIdentifier: [!Select [2, !Ref 'Subnets']]
+      LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
+      MinSize: 1
+      MaxSize: 1
+      DesiredCapacity: 1
+      NotificationConfigurations:
+        - TopicARN: !Ref 'ASGEventsTopic'
+          NotificationTypes:
+          - autoscaling:EC2_INSTANCE_TERMINATE
+      Tags:
+        - Key: Name
+          Value: !Sub 'ECS Container Instance - ${AWS::StackName}'
+          PropagateAtLaunch: true
+        - Key: Project
+          Value: !Ref 'Project'
+          PropagateAtLaunch: true
+        - Key: Team
+          Value: !Ref 'Team'
+          PropagateAtLaunch: true
+        - Key: Environment
+          Value: !Ref 'Environment'
+          PropagateAtLaunch: true
+        - Key: Component
+          Value: ecs
+          PropagateAtLaunch: true
+        - Key: Scheduler
+          Value: false
+          PropagateAtLaunch: true
+        - Key: AsgResourceName
+          Value: 'ECSAutoScalingGroup2'
           PropagateAtLaunch: true
     CreationPolicy:
       ResourceSignal:
@@ -682,10 +872,28 @@ Resources:
               Service: autoscaling.amazonaws.com
       ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AutoScalingNotificationAccessRole']
 
-  ECSAutoScalingGroupLifecycleHook:
+  ECSAutoScalingGroupLifecycleHook0:
     Type: AWS::AutoScaling::LifecycleHook
     Properties:
-      AutoScalingGroupName: !Ref 'ECSAutoScalingGroup'
+      AutoScalingGroupName: !Ref 'ECSAutoScalingGroup0'
+      LifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING'
+      NotificationTargetARN: !Ref 'ASGEventsTopic'
+      RoleARN: !GetAtt 'ECSAutoScalingNotificationAccessRole.Arn'
+      DefaultResult: 'ABANDON'
+      HeartbeatTimeout: '300'
+  ECSAutoScalingGroupLifecycleHook1:
+    Type: AWS::AutoScaling::LifecycleHook
+    Properties:
+      AutoScalingGroupName: !Ref 'ECSAutoScalingGroup1'
+      LifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING'
+      NotificationTargetARN: !Ref 'ASGEventsTopic'
+      RoleARN: !GetAtt 'ECSAutoScalingNotificationAccessRole.Arn'
+      DefaultResult: 'ABANDON'
+      HeartbeatTimeout: '300'
+  ECSAutoScalingGroupLifecycleHook2:
+    Type: AWS::AutoScaling::LifecycleHook
+    Properties:
+      AutoScalingGroupName: !Ref 'ECSAutoScalingGroup2'
       LifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING'
       NotificationTargetARN: !Ref 'ASGEventsTopic'
       RoleARN: !GetAtt 'ECSAutoScalingNotificationAccessRole.Arn'
@@ -747,12 +955,18 @@ Resources:
       ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole']
 
 Outputs:
+  AsgName0:
+    Description: Name of first ASG created
+    Value: !Ref 'ECSAutoScalingGroup0'
+  AsgName1:
+    Description: Name of second ASG created
+    Value: !Ref 'ECSAutoScalingGroup1'
+  AsgName2:
+    Description: Name of third ASG created
+    Value: !Ref 'ECSAutoScalingGroup2'
   ClusterName:
     Description: A reference to the ECS cluster
     Value: !Ref 'ECSCluster'
-  AutoScalingGroupName:
-    Description: A reference to ECS AutoScaling Group Name
-    Value: !Ref 'ECSAutoScalingGroup'
   ServiceAutoScalingRole:
     Description: A reference to ECS service auto scaling role
     Value: !GetAtt 'ECSServiceAutoScalingRole.Arn'

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -77,6 +77,9 @@ Parameters:
   HostedZoneId:
     Description: The ID of the Hosted Zone in which to register services for service discovery
     Type: String
+  KinesisStackName:
+    Type: String
+    Description: Name of the CF stack used to create the Kinesis stream
 
   # Parameter to force a rolling deployment
   RollingDeploymentVersion:
@@ -137,6 +140,18 @@ Resources:
     Properties:
       LogGroupName: !Ref 'AWS::StackName'
       RetentionInDays: 3
+  SubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn:
+      - ECSLogGroup
+    Properties:
+      RoleArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Role-Arn
+      LogGroupName: !Ref 'ECSLogGroup'
+      FilterPattern: ''
+      DestinationArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Stream-Arn
+
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:
@@ -289,9 +304,9 @@ Resources:
         - !Ref 'AdditionalSecurityGroup'
       UserData:
         'Fn::Base64': !Sub |
-          #!/bin/bash
+          #!/bin/bash -e
 
-          exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+          exec >> /var/log/user-data.log 2>&1
 
           # Increment RollingDeploymentVersion parameter to force rolling deploy
           version=${RollingDeploymentVersion}
@@ -326,7 +341,6 @@ Resources:
           general:
             - install_logging
             - install_ecs_instance
-            - install_ecs
             - install_monitoring
             - install_service_discovery
           services:
@@ -369,7 +383,7 @@ Resources:
                 datetime_format = %Y-%m-%dT%H:%M:%S.%f
 
                 [/var/log/ecs/ecs-init.log]
-                file = /var/log/ecs/ecs-init.log.*
+                file = /var/log/ecs/ecs-init.log
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/ecs-init.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
@@ -378,12 +392,6 @@ Resources:
                 file = /var/log/ecs/ecs-agent.log.*
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/ecs-agent.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/ecs/audit.log]
-                file = /var/log/ecs/audit.log.*
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/audit.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
                 [/var/log/cloud-init.log]
@@ -422,12 +430,6 @@ Resources:
                 log_stream_name = {instance_id}/awslogs-config.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
-                [/var/log/data-volume.log]
-                file = /var/log/data-volume.log
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/data-volume.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
                 [/var/log/service-discovery.log]
                 file = /var/log/service-discovery.log
                 log_group_name = {cluster}
@@ -439,18 +441,6 @@ Resources:
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/docker-mirror.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/monitoring.log]
-                file = /var/log/monitoring.log
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/monitoring.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/setup-tags.log]
-                file = /var/log/setup-tags.log
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/setup-tags.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
             '/etc/init/awslogs.conf':
               content: |
                 #upstart-job
@@ -459,8 +449,8 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/awslogs-config.log
-
+                  exec >> /var/log/awslogs-config.log 2>&1
+                  set -e
                   set -x
 
                   until curl -s http://localhost:51678/v1/metadata
@@ -493,7 +483,7 @@ Resources:
                 # Tag this instance's related resources before attaching other resources that might have tags
                 # we shouldn't override.
 
-                exec > >(tee /var/log/setup-tags.log | logger -t setup-tags -s 2>/dev/console) 2>&1
+                exec >> /var/log/user-data.log 2>&1
 
                 # Setup environment variables
                 export AWS_DEFAULT_REGION=${AWS::Region}
@@ -514,7 +504,7 @@ Resources:
               content: !Sub |
                 #!/bin/bash -e
 
-                exec > >(tee /var/log/data-volume.log | logger -t data-volume -s 2>/dev/console) 2>&1
+                exec >> /var/log/user-data.log 2>&1
 
                 # Setup environment variables
 
@@ -593,11 +583,8 @@ Resources:
               command: '/usr/local/share/setup-tags'
             02_setup_ebs_volume:
               command: '/usr/local/share/setup-data-volume'
-
-        # Let ecs agent know which cluster to join
-        install_ecs:
-          commands:
-            01_add_instance_to_cluster:
+            03_add_instance_to_cluster:
+              # Let ecs agent know which cluster to join
               command: !Sub 'echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config'
 
         install_service_discovery:
@@ -613,7 +600,8 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/service-discovery.log
+                  exec >> /var/log/service-discovery.log 2>&1
+                  set -e
                   set -x
 
                   until curl -s http://localhost:51678/v1/metadata
@@ -667,7 +655,8 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/docker-mirror.log
+                  exec >> /var/log/docker-mirror.log 2>&1
+                  set -e
                   set -x
 
                   until curl -s http://169.254.169.254/latest/meta-data
@@ -713,9 +702,9 @@ Resources:
           commands:
             01_install_disk_mem_monitoring:
               command: |
-                #!/bin/bash
+                #!/bin/bash -e
 
-                exec 2>>/var/log/monitoring.log
+                exec >> /var/log/user-data.log 2>&1
                 set -e
                 set -x
 

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -552,7 +552,6 @@ Resources:
                 # Setup and mount data volume
                 echo "Setting up mount point for data volume..."
                 mkdir -p ${EBSMountPath}
-                chown -R root:root /var/private
 
                 echo "Mounting file system..."
                 echo "/dev/xvdh  ${EBSMountPath}  xfs  defaults,inode64,nofail,context=system_u:object_r:var_t:s0  0 2" >> /etc/fstab
@@ -568,12 +567,6 @@ Resources:
                 aws ec2 create-tags --resources $instance_id --tags Key=BrokerId,Value=$broker_id
                 echo $broker_id > /tmp/broker.id
 
-                # Get the Route53 recordset name
-                recordset_name=$(aws ec2 describe-volumes --volume-ids $volume_id | jq -r '.Volumes[0].Tags[] | select(.Key == "RecordSetName").Value')
-
-                # Add tag to the instance so we can identify the record set
-                echo "Setting up InstanceId=$instance_id for tag RecordSetName=$recordset_name..."
-                aws ec2 create-tags --resources $instance_id --tags Key=RecordSetName,Value=$recordset_name
           commands:
             01_setup_ebs_volume:
               command: '/usr/local/share/setup-data-volume'

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -505,12 +505,13 @@ Resources:
 
                 instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
                 instance_data=$(aws ec2 describe-instances --instance-id $instance_id)
+                instance_name=$(echo "$instance_data" | jq -r '.Reservations[0].Instances[0].Tags[] | select(.Key=="Name").Value')
                 network_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].NetworkInterfaces[].NetworkInterfaceId'))
                 volume_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].BlockDeviceMappings[].Ebs.VolumeId'))
 
                 echo "Setting up tags for '$instance_id'; resources=[${!volume_ids[@]} ${!network_ids[@]}]..."
-                tags="Key=Name,Value=$instance_name Key=Project,Value=${Project} Key=Team,Value=${Team} Key=Environment,Value=${Environment}"
-                aws ec2 create-tags --resources ${!volume_ids[@]} ${!network_ids[@]} --tags "$tags"
+                tags="'Key=Name,Value=\"${!instance_name}\"' 'Key=Project,Value=${Project}' 'Key=Team,Value=${Team}' 'Key=Environment,Value=${Environment}'"
+                eval aws ec2 create-tags --resources ${!volume_ids[@]} ${!network_ids[@]} --tags $tags
             '/usr/local/share/setup-data-volume':
               mode: '000744'
               owner: root

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -320,23 +320,23 @@ Resources:
             instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 
             echo "Grabbing tag of autoscaling resource name with instance id='$instance_id'"
-            asgresourcename=$(aws ec2 describe-tags --region ${AWS::Region} --filters Name=resource-id,Values=$instance_id Name=tag-key,Values=AsgResourceName | jq -r '.Tags[0].Value')
+            asg_resource_name=$(aws ec2 describe-tags --region ${AWS::Region} --filters Name=resource-id,Values=$instance_id Name=tag-key,Values=AsgResourceName | jq -r '.Tags[0].Value')
           fi
 
-          echo "Signalling ASG with resource name='$asgresourcename'"
-          /opt/aws/bin/cfn-signal -e $exit_code --region ${AWS::Region} --stack ${AWS::StackName} --resource $asgresourcename
+          echo "Signalling ASG with resource name='$asg_resource_name'"
+          /opt/aws/bin/cfn-signal -e $exit_code --region ${AWS::Region} --stack ${AWS::StackName} --resource $asg_resource_name
     Metadata:
       AWS::CloudFormation::Init:
         configSets:
           general:
-          - install_logging
-          - install_data_volume
-          - install_ecs
-          - install_monitoring
-          - install_service_discovery
+            - install_logging
+            - install_ecs_instance
+            - install_ecs
+            - install_monitoring
+            - install_service_discovery
           services:
-          - ConfigSet: general
-          - install_docker_mirror
+            - ConfigSet: general
+            - install_docker_mirror
 
         # Configure and install aws logs agent
         install_logging:
@@ -450,6 +450,12 @@ Resources:
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/monitoring.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/setup-tags.log]
+                file = /var/log/setup-tags.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/setup-tags.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
             '/etc/init/awslogs.conf':
               content: |
                 #upstart-job
@@ -480,14 +486,36 @@ Resources:
                   chkconfig awslogs on
                 end script
 
-        install_data_volume:
+        install_ecs_instance:
           files:
+            '/usr/local/share/setup-tags':
+              mode: '000744'
+              owner: root
+              group: root
+              content: !Sub |
+                #!/bin/bash -e
+
+                # Tag this instance's related resources before attaching other resources that might have tags
+                # we shouldn't override.
+
+                exec > >(tee /var/log/setup-tags.log | logger -t setup-tags -s 2>/dev/console) 2>&1
+
+                # Setup environment variables
+                export instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+                export AWS_DEFAULT_REGION=${AWS::Region}
+
+                network_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].NetworkInterfaces[].NetworkInterfaceId'))
+                volume_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].BlockDeviceMappings[].Ebs.VolumeId'))
+
+                echo "Setting up tags for '$instance_id'; resources=[${!volume_ids[@]} ${!network_ids[@]}]..."
+                tags="Key=Name,Value=$instance_name Key=Project,Value=${Project} Key=Team,Value=${Team} Key=Environment,Value=${Environment}"
+                aws ec2 create-tags --resources ${!volume_ids[@]} ${!network_ids[@]} --tags "$tags"
             '/usr/local/share/setup-data-volume':
               mode: '000744'
               owner: root
               group: root
               content: !Sub |
-                #!/bin/bash
+                #!/bin/bash -e
 
                 exec > >(tee /var/log/data-volume.log | logger -t data-volume -s 2>/dev/console) 2>&1
 
@@ -496,8 +524,6 @@ Resources:
                 export instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
                 export az=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
                 export AWS_DEFAULT_REGION=${AWS::Region}
-
-                #export asg_name=$(aws ec2 describe-tags --filters Name=resource-id,Values=$instance_id Name=tag-key,Values=AsgName | jq -r '.Tags[0].Value')
 
                 # This script will find next available volume in the instance's availability zone and attach it. It will
                 # initialize the file system if it is the first time it attaches; this is determined by existence of the
@@ -566,9 +592,10 @@ Resources:
                 echo "Setting up InstanceId=$instance_id for tag BrokerId=$broker_id..."
                 aws ec2 create-tags --resources $instance_id --tags Key=BrokerId,Value=$broker_id
                 echo $broker_id > /tmp/broker.id
-
           commands:
-            01_setup_ebs_volume:
+            01_setup_tags:
+              command: '/usr/local/share/setup-tags'
+            02_setup_ebs_volume:
               command: '/usr/local/share/setup-data-volume'
 
         # Let ecs agent know which cluster to join

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -1,7 +1,8 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 
-Description: Creates an ECS cluster
+Description: >
+  Creates an ECS cluster that expects data volumes for each ECS Instance to be precreated and tagged.
 
 Parameters:
   # Networking
@@ -56,30 +57,18 @@ Parameters:
     Default: /mnt/data
     MinLength: 1
     ConstraintDescription: Must be a valid folder path
-  EBSVolumeSize:
-    Description: Data volume size in GB for ECS instances. These will be exposed via EBSMountPath to containers.
-    Type: Number
-    MinValue: 25
-    MaxValue: 2000
-    Default: 100
-    ConstraintDescription: Must be a value between 25 and 250
 
   # ASG
   ASGEventsTopic:
     Description: SNS topic to notify of ASG events
     Type: String
-  ASGMinSize:
-    Description: Minimum size of ECS Auto Scaling Group
+  MinInstancesPerAsg:
+    Description: Minimum number of ECS instances. This controls how we can add more capacity.
     Type: Number
-  ASGMaxSize:
-    Description: Maximum size of ECS Auto Scaling Group
-    Type: Number
-  ASGDesiredCapacity:
-    Description: Desired Capacity of the ECS Auto Scaling Group
-    Type: Number
-  RollingUpdateMinInService:
-    Description: Minimum instance in service during rolling update
-    Type: Number
+    Default: 2
+    MinValue: 2
+    MaxValue: 5
+    ConstraintDescription: Must be a number between 2 and 5.
 
   # Features
   ClusterType:
@@ -124,7 +113,7 @@ Parameters:
     Type: String
   VolumeNameTag:
     Type: String
-    Description: Tag for identifying the component the volume should be tagged with
+    Description: Tag for identifying the data volume to use for the ECS instances
 
 Mappings:
   # These are the latest ECS optimized AMIs as of March 2018:
@@ -306,7 +295,7 @@ Resources:
         'Fn::Base64': !Sub |
           #!/bin/bash
 
-          exec 2>>/var/log/user-data.log
+          exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
           # Increment RollingDeploymentVersion parameter to force rolling deploy
           version=${RollingDeploymentVersion}
@@ -430,6 +419,36 @@ Resources:
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/user-data.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/awslogs-config.log]
+                file = /var/log/awslogs-config.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/awslogs-config.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/data-volume.log]
+                file = /var/log/data-volume.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/data-volume.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/service-discovery.log]
+                file = /var/log/service-discovery.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/service-discovery.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/docker-mirror.log]
+                file = /var/log/docker-mirror.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/docker-mirror.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/monitoring.log]
+                file = /var/log/monitoring.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/monitoring.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
             '/etc/init/awslogs.conf':
               content: |
                 #upstart-job
@@ -438,7 +457,7 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/user-data.log
+                  exec 2>>/var/log/awslogs-config.log
 
                   set -x
 
@@ -469,8 +488,7 @@ Resources:
               content: !Sub |
                 #!/bin/bash
 
-                exec 2>>/var/log/user-data.log
-
+                exec > >(tee /var/log/data-volume.log | logger -t data-volume -s 2>/dev/console) 2>&1
 
                 # Setup environment variables
 
@@ -578,7 +596,7 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/user-data.log
+                  exec 2>>/var/log/service-discovery.log
                   set -x
 
                   until curl -s http://localhost:51678/v1/metadata
@@ -632,7 +650,7 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/user-data.log
+                  exec 2>>/var/log/docker-mirror.log
                   set -x
 
                   until curl -s http://169.254.169.254/latest/meta-data
@@ -680,7 +698,7 @@ Resources:
               command: |
                 #!/bin/bash
 
-                exec 2>>/var/log/user-data.log
+                exec 2>>/var/log/monitoring.log
                 set -e
                 set -x
 
@@ -715,7 +733,7 @@ Resources:
       VPCZoneIdentifier: [!Select [0, !Ref 'Subnets']]
       LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
       MinSize: 1
-      MaxSize: 1
+      MaxSize: !Ref 'MinInstancesPerAsg'
       DesiredCapacity: 1
       NotificationConfigurations:
         - TopicARN: !Ref 'ASGEventsTopic'
@@ -748,7 +766,7 @@ Resources:
         Timeout: PT15M
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MinInstancesInService: !Ref 'RollingUpdateMinInService'
+        MinInstancesInService: 1
         MaxBatchSize: 1
         PauseTime: PT15M
         SuspendProcesses:
@@ -765,7 +783,7 @@ Resources:
       VPCZoneIdentifier: [!Select [1, !Ref 'Subnets']]
       LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
       MinSize: 1
-      MaxSize: 1
+      MaxSize: !Ref 'MinInstancesPerAsg'
       DesiredCapacity: 1
       NotificationConfigurations:
         - TopicARN: !Ref 'ASGEventsTopic'
@@ -798,7 +816,7 @@ Resources:
         Timeout: PT15M
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MinInstancesInService: !Ref 'RollingUpdateMinInService'
+        MinInstancesInService: 1
         MaxBatchSize: 1
         PauseTime: PT15M
         SuspendProcesses:
@@ -815,7 +833,7 @@ Resources:
       VPCZoneIdentifier: [!Select [2, !Ref 'Subnets']]
       LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
       MinSize: 1
-      MaxSize: 1
+      MaxSize: !Ref 'MinInstancesPerAsg'
       DesiredCapacity: 1
       NotificationConfigurations:
         - TopicARN: !Ref 'ASGEventsTopic'
@@ -848,7 +866,7 @@ Resources:
         Timeout: PT15M
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MinInstancesInService: !Ref 'RollingUpdateMinInService'
+        MinInstancesInService: 1
         MaxBatchSize: 1
         PauseTime: PT15M
         SuspendProcesses:

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -40,12 +40,6 @@ Parameters:
     ]
     Default: m5.large
     ConstraintDescription: Must be a valid EC2 instance type
-  EBSOptimizedInstance:
-    Description: Enable EBS optimized flag. This will only work for instances that support it.
-    Type: String
-    AllowedValues: ['true', 'false']
-    Default: true
-    ConstraintDescription: Must be either 'true' or 'false'
   AdditionalSecurityGroup:
     Type: String
     Description: Additional security group to add ECS instances to
@@ -112,6 +106,7 @@ Parameters:
   ParentStackName:
     Description: Name of parent stack
     Type: String
+
   VolumeNameTag:
     Type: String
     Description: Tag for identifying the data volume to use for the ECS instances
@@ -284,7 +279,7 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       AssociatePublicIpAddress: false
-      EbsOptimized: !Ref 'EBSOptimizedInstance'
+      EbsOptimized: true
       IamInstanceProfile: !Ref 'ECSInstanceProfile'
       ImageId:  !FindInMap [AWSRegionToAMI, !Ref 'AWS::Region', AMI]
       InstanceType: !Ref 'InstanceType'
@@ -589,11 +584,10 @@ Resources:
                 echo "Setting up tag InstanceId=$instance_id for volume $volume_id..."
                 aws ec2 create-tags --resources $volume_id --tags Key=InstanceId,Value=$instance_id
 
-                # Get Broker Id from volume tag and transfer to instance
-                broker_id=$(aws ec2 describe-volumes --volume-ids $volume_id | jq -r '.Volumes[0].Tags[] | select(.Key == "BrokerId").Value')
-                echo "Setting up InstanceId=$instance_id for tag BrokerId=$broker_id..."
-                aws ec2 create-tags --resources $instance_id --tags Key=BrokerId,Value=$broker_id
-                echo $broker_id > /tmp/broker.id
+                # Get NodeId from volume tag and transfer to instance
+                node_id=$(aws ec2 describe-volumes --volume-ids $volume_id | jq -r '.Volumes[0].Tags[] | select(.Key == "NodeId").Value')
+                echo "Setting up InstanceId=$instance_id for tag NodeId=$node_id..."
+                aws ec2 create-tags --resources $instance_id --tags Key=NodeId,Value=$node_id
           commands:
             01_setup_tags:
               command: '/usr/local/share/setup-tags'

--- a/ecs-without-ebs.yaml
+++ b/ecs-without-ebs.yaml
@@ -501,9 +501,10 @@ Resources:
                 exec > >(tee /var/log/setup-tags.log | logger -t setup-tags -s 2>/dev/console) 2>&1
 
                 # Setup environment variables
-                export instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
                 export AWS_DEFAULT_REGION=${AWS::Region}
 
+                instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+                instance_data=$(aws ec2 describe-instances --instance-id $instance_id)
                 network_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].NetworkInterfaces[].NetworkInterfaceId'))
                 volume_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].BlockDeviceMappings[].Ebs.VolumeId'))
 

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -1,7 +1,7 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 
-Description: Creates an ECS cluster that attaches a secondary data volume to each ECS instance.
+Description: Creates an ECS cluster that uses a second encrypted data volume for each ECS instance.
 
 Parameters:
   # Networking

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -216,7 +216,10 @@ Resources:
               'ssm:PutConfigurePackageResult',
               'ssm:UpdateAssociationStatus',
               'ssm:UpdateInstanceAssociationStatus',
-              'ssm:UpdateInstanceInformation'
+              'ssm:UpdateInstanceInformation',
+              'ec2:DescribeInstances',
+              'ec2:DescribeTags',
+              'ec2:CreateTags'
             ]
             Effect: Allow
             Resource: '*'
@@ -499,9 +502,10 @@ Resources:
                 exec > >(tee /var/log/setup-tags.log | logger -t setup-tags -s 2>/dev/console) 2>&1
 
                 # Setup environment variables
-                export instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
                 export AWS_DEFAULT_REGION=${AWS::Region}
 
+                instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+                instance_data=$(aws ec2 describe-instances --instance-id $instance_id)
                 network_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].NetworkInterfaces[].NetworkInterfaceId'))
                 volume_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].BlockDeviceMappings[].Ebs.VolumeId'))
 

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -327,14 +327,14 @@ Resources:
       AWS::CloudFormation::Init:
         configSets:
           general:
-          - install_logging
-          - install_data_volume
-          - install_ecs
-          - install_monitoring
-          - install_service_discovery
+            - install_logging
+            - install_ecs_instance
+            - install_ecs
+            - install_monitoring
+            - install_service_discovery
           services:
-          - ConfigSet: general
-          - install_docker_mirror
+           - ConfigSet: general
+           - install_docker_mirror
 
         # Configure and install aws logs agent
         install_logging:
@@ -448,6 +448,12 @@ Resources:
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/monitoring.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/setup-tags.log]
+                file = /var/log/setup-tags.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/setup-tags.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
             '/etc/init/awslogs.conf':
               content: |
                 #upstart-job
@@ -478,8 +484,30 @@ Resources:
                   chkconfig awslogs on
                 end script
 
-        install_data_volume:
+        install_ecs_instance:
           files:
+            '/usr/local/share/setup-tags':
+              mode: '000744'
+              owner: root
+              group: root
+              content: !Sub |
+                #!/bin/bash -e
+
+                # Tag this instance's related resources before attaching other resources that might have tags
+                # we shouldn't override.
+
+                exec > >(tee /var/log/setup-tags.log | logger -t setup-tags -s 2>/dev/console) 2>&1
+
+                # Setup environment variables
+                export instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+                export AWS_DEFAULT_REGION=${AWS::Region}
+
+                network_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].NetworkInterfaces[].NetworkInterfaceId'))
+                volume_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].BlockDeviceMappings[].Ebs.VolumeId'))
+
+                echo "Setting up tags for '$instance_id'; resources=[${!volume_ids[@]} ${!network_ids[@]}]..."
+                tags="Key=Name,Value=$instance_name Key=Project,Value=${Project} Key=Team,Value=${Team} Key=Environment,Value=${Environment}"
+                aws ec2 create-tags --resources ${!volume_ids[@]} ${!network_ids[@]} --tags "$tags"
             '/usr/local/share/setup-data-volume':
               mode: '000744'
               owner: root
@@ -499,6 +527,8 @@ Resources:
                 echo "Mounting file system..."
                 mount -v ${EBSMountPath}
           commands:
+            01_setup_tags:
+              command: '/usr/local/share/setup-tags'
             01_setup_ebs_volume:
               command: '/usr/local/share/setup-data-volume'
 

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -506,12 +506,13 @@ Resources:
 
                 instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
                 instance_data=$(aws ec2 describe-instances --instance-id $instance_id)
+                instance_name=$(echo "$instance_data" | jq -r '.Reservations[0].Instances[0].Tags[] | select(.Key=="Name").Value')
                 network_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].NetworkInterfaces[].NetworkInterfaceId'))
                 volume_ids=($(echo $instance_data | jq -r '.Reservations[0].Instances[0].BlockDeviceMappings[].Ebs.VolumeId'))
 
                 echo "Setting up tags for '$instance_id'; resources=[${!volume_ids[@]} ${!network_ids[@]}]..."
-                tags="Key=Name,Value=$instance_name Key=Project,Value=${Project} Key=Team,Value=${Team} Key=Environment,Value=${Environment}"
-                aws ec2 create-tags --resources ${!volume_ids[@]} ${!network_ids[@]} --tags "$tags"
+                tags="'Key=Name,Value=\"${!instance_name}\"' 'Key=Project,Value=${Project}' 'Key=Team,Value=${Team}' 'Key=Environment,Value=${Environment}'"
+                eval aws ec2 create-tags --resources ${!volume_ids[@]} ${!network_ids[@]} --tags $tags
             '/usr/local/share/setup-data-volume':
               mode: '000744'
               owner: root

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -38,12 +38,6 @@ Parameters:
     ]
     Default: m5.large
     ConstraintDescription: Must be a valid EC2 instance type
-  EBSOptimizedInstance:
-    Description: Enable EBS optimized flag. This will only work for instances that support it.
-    Type: String
-    AllowedValues: ['true', 'false']
-    Default: true
-    ConstraintDescription: Must be either 'true' or 'false'
   AdditionalSecurityGroup:
     Type: String
     Description: Additional security group to add ECS instances to
@@ -285,7 +279,7 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       AssociatePublicIpAddress: false
-      EbsOptimized: !Ref 'EBSOptimizedInstance'
+      EbsOptimized: true
       BlockDeviceMappings:
         - DeviceName: '/dev/xvdh'
           Ebs:

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -1,7 +1,7 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 
-Description: Creates an ECS cluster
+Description: Creates an ECS cluster that attaches a secondary data volume to each ECS instance.
 
 Parameters:
   # Networking
@@ -301,7 +301,7 @@ Resources:
         'Fn::Base64': !Sub |
           #!/bin/bash
 
-          exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+          exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
           # Increment RollingDeploymentVersion parameter to force rolling deploy
           version=${RollingDeploymentVersion}
@@ -418,6 +418,36 @@ Resources:
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/user-data.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/awslogs-config.log]
+                file = /var/log/awslogs-config.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/awslogs-config.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/data-volume.log]
+                file = /var/log/data-volume.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/data-volume.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/service-discovery.log]
+                file = /var/log/service-discovery.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/service-discovery.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/docker-mirror.log]
+                file = /var/log/docker-mirror.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/docker-mirror.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+                [/var/log/monitoring.log]
+                file = /var/log/monitoring.log
+                log_group_name = {cluster}
+                log_stream_name = {instance_id}/monitoring.log
+                datetime_format = %Y-%m-%dT%H:%M:%SZ
             '/etc/init/awslogs.conf':
               content: |
                 #upstart-job
@@ -426,7 +456,7 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/user-data.log
+                  exec 2>>/var/log/awslogs-config.log
 
                   set -x
 
@@ -457,7 +487,7 @@ Resources:
               content: !Sub |
                 #!/bin/bash -e
 
-                exec > >(tee /var/log/user-data.log|logger -t setup-data-volume -s 2>/dev/console) 2>&1
+                exec > >(tee /var/log/data-volume.log | logger -t data-volume -s 2>/dev/console) 2>&1
 
                 echo "Creating XFS file system on /dev/xvdh..."
                 mkfs.xfs -f /dev/xvdh
@@ -491,7 +521,7 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/user-data.log
+                  exec 2>>/var/log/service-discovery.log
                   set -x
 
                   until curl -s http://localhost:51678/v1/metadata
@@ -545,7 +575,7 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/user-data.log
+                  exec 2>>/var/log/docker-mirror.log
                   set -x
 
                   until curl -s http://169.254.169.254/latest/meta-data
@@ -593,7 +623,7 @@ Resources:
               command: |
                 #!/bin/bash
 
-                exec 2>>/var/log/user-data.log
+                exec 2>>/var/log/monitoring.log
                 set -e
                 set -x
 

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -119,19 +119,19 @@ Parameters:
 Mappings:
   # These are the latest ECS optimized AMIs as of March 2018:
   #
-  #   amzn-ami-2017.09.j-amazon-ecs-optimized
-  #   ECS agent:    1.17.2
-  #   Docker:       17.12.0-ce
-  #   ecs-init:     1.17.2-1
+  #   amzn-ami-2017.09.l-amazon-ecs-optimized
+  #   ECS agent:    1.17.3
+  #   Docker:       17.12.1-ce
+  #   ecs-init:     1.17.3-1
   #
   # You can find the latest available on this page of our documentation:
   # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
   # (note the AMI identifier is region specific)
   AWSRegionToAMI:
     us-east-1:
-      AMI: ami-cad827b7
+      AMI: ami-aff65ad2
     ca-central-1:
-      AMI: ami-db48cfbf
+      AMI: ami-897ff9ed
 
 Conditions:
   IsClusterTypeService: !Equals [!Ref 'ClusterType', 'service']

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -87,6 +87,9 @@ Parameters:
   HostedZoneId:
     Description: The ID of the Hosted Zone in which to register services for service discovery
     Type: String
+  KinesisStackName:
+    Type: String
+    Description: Name of the CF stack used to create the Kinesis stream
 
   # Parameter to force a rolling deployment
   RollingDeploymentVersion:
@@ -139,6 +142,18 @@ Resources:
     Properties:
       LogGroupName: !Ref 'AWS::StackName'
       RetentionInDays: 3
+  SubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn:
+      - ECSLogGroup
+    Properties:
+      RoleArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Role-Arn
+      LogGroupName: !Ref 'ECSLogGroup'
+      FilterPattern: ''
+      DestinationArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Stream-Arn
+
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:
@@ -296,9 +311,9 @@ Resources:
         - !Ref 'AdditionalSecurityGroup'
       UserData:
         'Fn::Base64': !Sub |
-          #!/bin/bash
+          #!/bin/bash -e
 
-          exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+          exec >> /var/log/user-data.log 2>&1
 
           # Increment RollingDeploymentVersion parameter to force rolling deploy
           version=${RollingDeploymentVersion}
@@ -326,7 +341,6 @@ Resources:
           general:
             - install_logging
             - install_ecs_instance
-            - install_ecs
             - install_monitoring
             - install_service_discovery
           services:
@@ -380,12 +394,6 @@ Resources:
                 log_stream_name = {instance_id}/ecs-agent.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
-                [/var/log/ecs/audit.log]
-                file = /var/log/ecs/audit.log.*
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/audit.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
                 [/var/log/cloud-init.log]
                 file = /var/log/cloud-init.log
                 log_group_name = {cluster}
@@ -422,12 +430,6 @@ Resources:
                 log_stream_name = {instance_id}/awslogs-config.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
-                [/var/log/data-volume.log]
-                file = /var/log/data-volume.log
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/data-volume.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
                 [/var/log/service-discovery.log]
                 file = /var/log/service-discovery.log
                 log_group_name = {cluster}
@@ -439,18 +441,6 @@ Resources:
                 log_group_name = {cluster}
                 log_stream_name = {instance_id}/docker-mirror.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/monitoring.log]
-                file = /var/log/monitoring.log
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/monitoring.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/setup-tags.log]
-                file = /var/log/setup-tags.log
-                log_group_name = {cluster}
-                log_stream_name = {instance_id}/setup-tags.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
             '/etc/init/awslogs.conf':
               content: |
                 #upstart-job
@@ -459,8 +449,8 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/awslogs-config.log
-
+                  exec >> /var/log/awslogs-config.log 2>&1
+                  set -e
                   set -x
 
                   until curl -s http://localhost:51678/v1/metadata
@@ -493,7 +483,7 @@ Resources:
                 # Tag this instance's related resources before attaching other resources that might have tags
                 # we shouldn't override.
 
-                exec > >(tee /var/log/setup-tags.log | logger -t setup-tags -s 2>/dev/console) 2>&1
+                exec >> /var/log/user-data.log 2>&1
 
                 # Setup environment variables
                 export AWS_DEFAULT_REGION=${AWS::Region}
@@ -514,7 +504,7 @@ Resources:
               content: !Sub |
                 #!/bin/bash -e
 
-                exec > >(tee /var/log/data-volume.log | logger -t data-volume -s 2>/dev/console) 2>&1
+                exec >> /var/log/user-data.log 2>&1
 
                 echo "Creating XFS file system on /dev/xvdh..."
                 mkfs.xfs -f /dev/xvdh
@@ -528,13 +518,10 @@ Resources:
           commands:
             01_setup_tags:
               command: '/usr/local/share/setup-tags'
-            01_setup_ebs_volume:
+            02_setup_ebs_volume:
               command: '/usr/local/share/setup-data-volume'
-
-        # Let ecs agent know which cluster to join
-        install_ecs:
-          commands:
-            01_add_instance_to_cluster:
+            03_add_instance_to_cluster:
+              # Let ecs agent know which cluster to join
               command: !Sub 'echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config'
 
         install_service_discovery:
@@ -550,7 +537,8 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/service-discovery.log
+                  exec >> /var/log/service-discovery.log 2>&1
+                  set -e
                   set -x
 
                   until curl -s http://localhost:51678/v1/metadata
@@ -604,7 +592,8 @@ Resources:
                 start on started ecs
 
                 script
-                  exec 2>>/var/log/docker-mirror.log
+                  exec >> /var/log/docker-mirror.log 2>&1
+                  set -e
                   set -x
 
                   until curl -s http://169.254.169.254/latest/meta-data
@@ -650,9 +639,9 @@ Resources:
           commands:
             01_install_disk_mem_monitoring:
               command: |
-                #!/bin/bash
+                #!/bin/bash -e
 
-                exec 2>>/var/log/monitoring.log
+                exec >> /var/log/user-data.log 2>&1
                 set -e
                 set -x
 

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -621,7 +621,7 @@ Resources:
               mode: '000644'
               owner: root
               group: root
-  ECSAutoScalingGroup:
+  ECSAutoScalingGroup0:
     DependsOn: 'ECSLogGroup'
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
@@ -668,6 +668,100 @@ Resources:
           - AlarmNotification
           - ScheduledActions
         WaitOnResourceSignals: true
+ECSAutoScalingGroup1:
+  DependsOn: 'ECSLogGroup'
+  Type: AWS::AutoScaling::AutoScalingGroup
+  Properties:
+    VPCZoneIdentifier: !Ref 'Subnets'
+    LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
+    MinSize: !Ref 'ASGMinSize'
+    MaxSize: !Ref 'ASGMaxSize'
+    DesiredCapacity: !Ref 'ASGDesiredCapacity'
+    NotificationConfigurations:
+      - TopicARN: !Ref 'ASGEventsTopic'
+        NotificationTypes:
+        - autoscaling:EC2_INSTANCE_TERMINATE
+    Tags:
+      - Key: Name
+        Value: !Sub 'ECS Container Instance - ${AWS::StackName}'
+        PropagateAtLaunch: true
+      - Key: Project
+        Value: !Ref 'Project'
+        PropagateAtLaunch: true
+      - Key: Team
+        Value: !Ref 'Team'
+        PropagateAtLaunch: true
+      - Key: Environment
+        Value: !Ref 'Environment'
+        PropagateAtLaunch: true
+      - Key: Component
+        Value: ecs
+        PropagateAtLaunch: true
+      - Key: Scheduler
+        Value: false
+        PropagateAtLaunch: true
+  CreationPolicy:
+    ResourceSignal:
+      Timeout: PT15M
+  UpdatePolicy:
+    AutoScalingRollingUpdate:
+      MinInstancesInService: !Ref 'RollingUpdateMinInService'
+      MaxBatchSize: 1
+      PauseTime: PT15M
+      SuspendProcesses:
+        - HealthCheck
+        - ReplaceUnhealthy
+        - AZRebalance
+        - AlarmNotification
+        - ScheduledActions
+      WaitOnResourceSignals: true
+ECSAutoScalingGroup2:
+  DependsOn: 'ECSLogGroup'
+  Type: AWS::AutoScaling::AutoScalingGroup
+  Properties:
+    VPCZoneIdentifier: !Ref 'Subnets'
+    LaunchConfigurationName: !Ref 'ECSLaunchConfiguration'
+    MinSize: !Ref 'ASGMinSize'
+    MaxSize: !Ref 'ASGMaxSize'
+    DesiredCapacity: !Ref 'ASGDesiredCapacity'
+    NotificationConfigurations:
+      - TopicARN: !Ref 'ASGEventsTopic'
+        NotificationTypes:
+        - autoscaling:EC2_INSTANCE_TERMINATE
+    Tags:
+      - Key: Name
+        Value: !Sub 'ECS Container Instance - ${AWS::StackName}'
+        PropagateAtLaunch: true
+      - Key: Project
+        Value: !Ref 'Project'
+        PropagateAtLaunch: true
+      - Key: Team
+        Value: !Ref 'Team'
+        PropagateAtLaunch: true
+      - Key: Environment
+        Value: !Ref 'Environment'
+        PropagateAtLaunch: true
+      - Key: Component
+        Value: ecs
+        PropagateAtLaunch: true
+      - Key: Scheduler
+        Value: false
+        PropagateAtLaunch: true
+  CreationPolicy:
+    ResourceSignal:
+      Timeout: PT15M
+  UpdatePolicy:
+    AutoScalingRollingUpdate:
+      MinInstancesInService: !Ref 'RollingUpdateMinInService'
+      MaxBatchSize: 1
+      PauseTime: PT15M
+      SuspendProcesses:
+        - HealthCheck
+        - ReplaceUnhealthy
+        - AZRebalance
+        - AlarmNotification
+        - ScheduledActions
+      WaitOnResourceSignals: true
 
   ECSAutoScalingNotificationAccessRole:
     Type: AWS::IAM::Role

--- a/jmxtrans/Dockerfile
+++ b/jmxtrans/Dockerfile
@@ -20,8 +20,10 @@ ENV JMXTRANS_ALIASES=zookeeper
 COPY config/*.json /usr/local/share/config/
 COPY bootstrap /usr/local/bin/
 
-# Load a JMX client
-RUN wget -P /usr/local/share http://crawler.archive.org/cmdline-jmxclient/cmdline-jmxclient-0.10.3.jar
+# Install jq and load a JMX client
+RUN apk update && \
+    apk add jq && \
+    wget -P /usr/local/share http://crawler.archive.org/cmdline-jmxclient/cmdline-jmxclient-0.10.3.jar
 
 # Execute our bootstrap before jmxtrans' entry point before starting the container.
 ENTRYPOINT ["/usr/local/bin/bootstrap", "/docker-entrypoint.sh"]

--- a/kafka-connect/service.yaml
+++ b/kafka-connect/service.yaml
@@ -17,14 +17,22 @@ Parameters:
   AppName:
     Type: String
     Description: Name of app. Should be the same as docker repository name.
-  Memory:
+  ServiceMemory:
     Type: Number
     Description: Soft memory on container
     Default: '1024'
-  Cpu:
+  ServiceCpu:
     Type: Number
     Description: cpu unites on container
-    Default: '100'
+    Default: '128'
+  JmxtransMemory:
+    Type: Number
+    Description: Soft memory on container
+    Default: '512'
+  JmxtransCpu:
+    Type: Number
+    Description: cpu unites on container
+    Default: '128'
   AppDesiredCount:
     Type: Number
     Description: Number of instances of the service to run
@@ -143,13 +151,13 @@ Resources:
       ContainerDefinitions:
         - Name: !Ref 'AppName'
           Image: loyaltyone/cp-kafka-connect:0.1-beta
-          Cpu: !Ref 'Cpu'
+          Cpu: !Ref 'ServiceCpu'
           PortMappings:
             - ContainerPort: !Ref 'AppContainerPort'
               HostPort: 0
             - ContainerPort: !Ref 'JMXPort'
               HostPort: !Ref 'JMXPort'
-          MemoryReservation: !Ref 'Memory'
+          MemoryReservation: !Ref 'ServiceMemory'
           Essential: 'true'
           LogConfiguration:
             LogDriver: awslogs
@@ -196,8 +204,8 @@ Resources:
               Value: !Ref 'JMXPort'
         - Name: jmxtrans
           Image: loyaltyone/jmxtrans:0.1-beta
-          Cpu: '512'
-          MemoryReservation: '2048'
+          Cpu: !Ref 'JmxtransCpu'
+          MemoryReservation: !Ref 'JmxtransMemory'
           Links: [!Ref 'AppName']
           Environment:
             - Name: SECONDS_BETWEEN_RUNS

--- a/kafka-connect/service.yaml
+++ b/kafka-connect/service.yaml
@@ -36,7 +36,7 @@ Parameters:
   AppDesiredCount:
     Type: Number
     Description: Number of instances of the service to run
-    Default: '1'
+    Default: '2'
   AppMaxCount:
     Type: Number
     Description: Max number of instances of the service to scale out to

--- a/kafka-rest/service.yaml
+++ b/kafka-rest/service.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Creates a service / task def for Kafka REST Proxy
+Description: >
+  Creates a service / task def for Kafka REST Proxy.
+  Note that if you use more than 1 node, there will be issues using the cluster as a consumer
+  group. The REST Proxy requires using individual nodes directly which not possible in this setup.
 Parameters:
   Cluster:
     Description: Name of an active CloudFormation stack that contains an ECS cluster

--- a/kafka-rest/service.yaml
+++ b/kafka-rest/service.yaml
@@ -18,14 +18,22 @@ Parameters:
     Type: String
     Description: Name of app
     Default: cp-kafka-rest  
-  Memory:
+  ServiceMemory:
     Type: Number
     Description: Soft memory on container
-    Default: '1280'
-  Cpu:
+    Default: '1024'
+  ServiceCpu:
     Type: Number
     Description: cpu unites on container
-    Default: '100'
+    Default: '128'
+  JmxtransMemory:
+    Type: Number
+    Description: Soft memory on container
+    Default: '512'
+  JmxtransCpu:
+    Type: Number
+    Description: cpu unites on container
+    Default: '128'
   AppDesiredCount:
     Type: Number
     Description: Number of instances of the service to run
@@ -137,13 +145,13 @@ Resources:
       ContainerDefinitions:
         - Name: !Ref 'AppName'
           Image: loyaltyone/cp-kafka-rest:0.1-beta
-          Cpu: !Ref 'Cpu'
+          Cpu: !Ref 'ServiceCpu'
           PortMappings:
             - ContainerPort: !Ref 'AppContainerPort'
               HostPort: 0
             - ContainerPort: !Ref 'JMXPort'
               HostPort: !Ref 'JMXPort'
-          MemoryReservation: !Ref 'Memory'
+          MemoryReservation: !Ref 'ServiceMemory'
           Essential: 'true'
           LogConfiguration:
             LogDriver: awslogs
@@ -166,8 +174,8 @@ Resources:
               Value: !Ref 'JMXPort'
         - Name: jmxtrans
           Image: loyaltyone/jmxtrans:0.1-beta
-          Cpu: '512'
-          MemoryReservation: '2048'
+          Cpu: !Ref 'JmxtransCpu'
+          MemoryReservation: !Ref 'JmxtransMemory'
           Links: [!Ref 'AppName']
           Environment:
             - Name: SECONDS_BETWEEN_RUNS

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -65,6 +65,9 @@ Parameters:
   DomainName:
     Description: The domain name for Kafka brokers
     Type: String
+  KinesisStackName:
+    Type: String
+    Description: Name of the CF stack used to create the Kinesis stream
 
 Resources:
   BrokersLogGroup:
@@ -72,6 +75,18 @@ Resources:
     Properties:
       LogGroupName: !Sub '${StackName}/kafka'
       RetentionInDays: 1
+  SubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn:
+      - BrokersLogGroup
+    Properties:
+      RoleArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Role-Arn
+      LogGroupName: !Ref 'BrokersLogGroup'
+      FilterPattern: ''
+      DestinationArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Stream-Arn
+
   ClientKafkaSG:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -188,7 +188,7 @@ Resources:
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 1, !Ref 'Subnets' ]
-    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG', 'Broker1']
+    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
   Broker3:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -209,7 +209,7 @@ Resources:
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 2, !Ref 'Subnets' ]
-    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG', 'Broker2']
+    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
 
 Outputs:
   ClientKafkaSG:

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -25,10 +25,6 @@ Parameters:
     Description: Kafka client port
     Type: Number
     Default: 9092
-  JMXPort:
-    Description: JMX Port to expose metrics on
-    Type: Number
-    Default: 8989
   ZookeeperConnectionString:
     Description: Connection string for Zookeeper Cluster
     Type: String
@@ -38,14 +34,22 @@ Parameters:
   InternalSG:
     Description: Security Group ID of the ECS Instances to allow JMX and client port ingress for this component
     Type: String
-  Cpu:
-    Description: Amount of CPU to reserve
+  ServiceCpu:
+    Description: CPU (1024 = 1 core)
     Type: Number
-    Default: 1024
-  Memory:
-    Description: Amount of Memory to reserve
+    Default: 896
+  ServiceMemory:
+    Description: Memory
     Type: Number
     Default: 4096
+  JmxtransCpu:
+    Description: CPU (1024 = 1 core)
+    Type: Number
+    Default: 128
+  JmxtransMemory:
+    Description: Memory
+    Type: Number
+    Default: 512
   Project:
     Description: Project tag
     Type: String
@@ -142,16 +146,16 @@ Resources:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       IpProtocol: tcp
-      FromPort: !Ref 'JMXPort'
-      ToPort: !Ref 'JMXPort'
+      FromPort: 8990
+      ToPort: 8992
       GroupId: !Ref 'InternalKafkaSG'
       SourceSecurityGroupId: !Ref 'InternalKafkaSG'
   InternalSGIngressJMXRule:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       IpProtocol: tcp
-      FromPort: !Ref 'JMXPort'
-      ToPort: !Ref 'JMXPort'
+      FromPort: 8990
+      ToPort: 8992
       GroupId: !Ref 'InternalKafkaSG'
       SourceSecurityGroupId: !Ref 'InternalSG'
   InternalSGClientIngressRule:
@@ -169,8 +173,10 @@ Resources:
       Parameters:
         Cluster: !Ref 'Cluster'
         StackName: !Ref 'StackName'
-        Cpu: !Ref 'Cpu'
-        Memory: !Ref 'Memory'
+        ServiceCpu: !Ref 'ServiceCpu'
+        ServiceMemory: !Ref 'ServiceMemory'
+        JmxtransCpu: !Ref 'JmxtransCpu'
+        JmxtransMemory: !Ref 'JmxtransMemory'
         DataVolumeMountPath: !Ref 'DataVolumeMountPath'
         ZookeeperConnectionString: !Ref 'ZookeeperConnectionString'
         ZookeeperSecurityGroup: !Ref 'ZookeeperSecurityGroup'
@@ -178,10 +184,10 @@ Resources:
         BrokerName: !Sub '${StackName}-broker'
         DomainName: !Ref 'DomainName'
         ClientPort: !Ref 'ClientPort'
-        JMXPort: !Ref 'JMXPort'
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 0, !Ref 'Subnets' ]
+        JMXPort: 8990
     DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
   Broker2:
     Type: 'AWS::CloudFormation::Stack'
@@ -190,8 +196,10 @@ Resources:
       Parameters:
         Cluster: !Ref 'Cluster'
         StackName: !Ref 'StackName'
-        Cpu: !Ref 'Cpu'
-        Memory: !Ref 'Memory'
+        ServiceCpu: !Ref 'ServiceCpu'
+        ServiceMemory: !Ref 'ServiceMemory'
+        JmxtransCpu: !Ref 'JmxtransCpu'
+        JmxtransMemory: !Ref 'JmxtransMemory'
         DataVolumeMountPath: !Ref 'DataVolumeMountPath'
         ZookeeperConnectionString: !Ref 'ZookeeperConnectionString'
         ZookeeperSecurityGroup: !Ref 'ZookeeperSecurityGroup'
@@ -199,10 +207,10 @@ Resources:
         BrokerName: !Sub '${StackName}-broker'
         DomainName: !Ref 'DomainName'
         ClientPort: !Ref 'ClientPort'
-        JMXPort: !Ref 'JMXPort'
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 1, !Ref 'Subnets' ]
+        JMXPort: 8991
     DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
   Broker3:
     Type: 'AWS::CloudFormation::Stack'
@@ -211,8 +219,10 @@ Resources:
       Parameters:
         Cluster: !Ref 'Cluster'
         StackName: !Ref 'StackName'
-        Cpu: !Ref 'Cpu'
-        Memory: !Ref 'Memory'
+        ServiceCpu: !Ref 'ServiceCpu'
+        ServiceMemory: !Ref 'ServiceMemory'
+        JmxtransCpu: !Ref 'JmxtransCpu'
+        JmxtransMemory: !Ref 'JmxtransMemory'
         DataVolumeMountPath: !Ref 'DataVolumeMountPath'
         ZookeeperConnectionString: !Ref 'ZookeeperConnectionString'
         ZookeeperSecurityGroup: !Ref 'ZookeeperSecurityGroup'
@@ -220,10 +230,10 @@ Resources:
         BrokerName: !Sub '${StackName}-broker'
         DomainName: !Ref 'DomainName'
         ClientPort: !Ref 'ClientPort'
-        JMXPort: !Ref 'JMXPort'
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 2, !Ref 'Subnets' ]
+        JMXPort: 8992
     DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
 
 Outputs:

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -10,14 +10,22 @@ Parameters:
   StackName:
     Description: The Parent Stack Name
     Type: String
-  Cpu:
+  ServiceCpu:
     Description: CPU (1024 = 1 core)
     Type: Number
-    Default: 1024
-  Memory:
+    Default: 896
+  ServiceMemory:
     Description: Memory
     Type: Number
     Default: 4096
+  JmxtransCpu:
+    Description: CPU (1024 = 1 core)
+    Type: Number
+    Default: 128
+  JmxtransMemory:
+    Description: Memory
+    Type: Number
+    Default: 512
   DataVolumeMountPath:
     Description: Path to directory for mounting data
     Type: String
@@ -64,8 +72,8 @@ Resources:
       ContainerDefinitions:
       - Name: broker
         Image: loyaltyone/cp-kafka:0.1-beta
-        Cpu: !Ref 'Cpu'
-        MemoryReservation: !Ref 'Memory'
+        Cpu: !Ref 'ServiceCpu'
+        MemoryReservation: !Ref 'ServiceMemory'
         User: root
         DockerLabels:
           'discovery.service.name': !Sub '${BrokerName}${BrokerId}'
@@ -102,8 +110,8 @@ Resources:
             awslogs-stream-prefix: !Sub 'broker${BrokerId}'
       - Name: jmxtrans
         Image: loyaltyone/jmxtrans:0.1-beta
-        Cpu: '512'
-        MemoryReservation: '2048'
+        Cpu: !Ref 'JmxtransCpu'
+        MemoryReservation: !Ref 'JmxtransMemory'
         Environment:
           - Name: SECONDS_BETWEEN_RUNS
             Value: 60

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -162,7 +162,7 @@ Resources:
   ECSBrokers:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
-      TemplateURL: ./ecs-without-ebs.yaml
+      TemplateURL: ./ecs-kafka.yaml
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
@@ -227,7 +227,7 @@ Resources:
   ECSZK:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
-      TemplateURL: ./ecs-without-ebs.yaml
+      TemplateURL: ./ecs-kafka.yaml
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -167,10 +167,7 @@ Resources:
         Subnets: !Join [",", [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
         InstanceType: !Ref 'BrokerInstanceType'
         EBSOptimizedInstance: 'true'
-        ASGMinSize: 3
-        ASGMaxSize: 3
-        ASGDesiredCapacity: 3
-        RollingUpdateMinInService: !Ref 'RollingUpdateMinInService'
+        MinInstancesPerAsg: 2
         ASGEventsTopic: !Ref 'ASGEventsTopic'
         Project: !Ref 'Project'
         Team: !Ref 'Team'
@@ -178,7 +175,6 @@ Resources:
         ClusterType: kafka
         HostedZoneId: !ImportValue
           'Fn::Sub': "${HostedZoneStackName}-ZoneId"
-        EBSVolumeSize: !Ref 'BrokerDataVolumeSize'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -30,6 +30,9 @@ Parameters:
   Subnets:
     Description: Choose three private subnets this cluster should be deployed to
     Type: List<AWS::EC2::Subnet::Id>
+  AvailabilityZones:
+    Description: Comma-separated list of three availability zones this cluster should be deployed to - must be in the same corresponding order as the Subnets parameter
+    Type: CommaDelimitedList
   BastionSG:
     Description: Security group used to whitelist for SSH access
     Type: AWS::EC2::SecurityGroup::Id
@@ -157,7 +160,7 @@ Resources:
   ECSBrokers:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
-      TemplateURL: ./ecs.yaml
+      TemplateURL: ./ecs-without-ebs.yaml
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
@@ -179,6 +182,45 @@ Resources:
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
+        ParentStackName: !Ref 'AWS::StackName'
+        VolumeNameTag: 'brokerdata'
+    DependsOn: ['EBSBrokers0','EBSBrokers1','EBSBrokers2']
+  EBSBrokers0:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: ./ebs.yaml
+      Parameters:
+        DataVolumeSize: !Ref BrokerDataVolumeSize
+        DataVolumeIOPS: ''
+        AvailabilityZone:  !Select [0, !Ref 'AvailabilityZones']
+        Project: !Ref Project
+        Team: !Ref Team
+        Environment: !Ref Environment
+        VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
+  EBSBrokers1:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: ./ebs.yaml
+      Parameters:
+        DataVolumeSize: !Ref BrokerDataVolumeSize
+        DataVolumeIOPS: ''
+        AvailabilityZone: !Select [1, !Ref 'AvailabilityZones']
+        Project: !Ref Project
+        Team: !Ref Team
+        Environment: !Ref Environment
+        VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
+  EBSBrokers2:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: ./ebs.yaml
+      Parameters:
+        DataVolumeSize: !Ref BrokerDataVolumeSize
+        DataVolumeIOPS: ''
+        AvailabilityZone: !Select [2, !Ref 'AvailabilityZones']
+        Project: !Ref Project
+        Team: !Ref Team
+        Environment: !Ref Environment
+        VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
   ECSZK:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -204,7 +246,6 @@ Resources:
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
-
   Services:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -312,17 +353,17 @@ Outputs:
     Description: 'The URL for Kafka Schema Registry'
     Value: !GetAtt 'Services.Outputs.SchemaRegistryURL'
     Export:
-      Name: !Sub '${AWS::StackName}-SchemaRegistryURL'      
+      Name: !Sub '${AWS::StackName}-SchemaRegistryURL'
   SchemaRegistryUIURL:
     Description: 'The URL for Kafka Schema Registry'
     Value: !GetAtt 'Services.Outputs.SchemaRegistryUIURL'
     Export:
-      Name: !Sub '${AWS::StackName}-SchemaRegistryUIURL'      
+      Name: !Sub '${AWS::StackName}-SchemaRegistryUIURL'
   RestProxyURL:
     Description: 'The URL for Kafka Rest Proxy'
     Value: !GetAtt 'Services.Outputs.KafkaRestURL'
     Export:
-      Name: !Sub '${AWS::StackName}-KafkaRestURL'      
+      Name: !Sub '${AWS::StackName}-KafkaRestURL'
   VpcId:
     Description: "Cluster's VPC Id"
     Value: !Ref 'VPCId'

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -2,9 +2,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
 Description: >
-  This template deploys a highly available ECS cluster using an AutoScaling Group, with
-  ECS hosts distributed across multiple Availability Zones. It then deploys a Zookeeper
-  cluster from containers published in Docker Hub.
+  This template deploys a highly available ECS cluster using an AutoScaling Group, with ECS hosts distributed across
+  3 availability zones. It then deploys a Zookeeper cluster from containers published in Docker Hub.
 
 Parameters:
   # Parameter to force a rolling deployment
@@ -31,7 +30,9 @@ Parameters:
     Description: Choose three private subnets this cluster should be deployed to
     Type: List<AWS::EC2::Subnet::Id>
   AvailabilityZones:
-    Description: Comma-separated list of three availability zones this cluster should be deployed to - must be in the same corresponding order as the Subnets parameter
+    Description: >
+      Comma-separated list of 3 availability zones this cluster should be deployed to - must be in the same
+      corresponding order as the Subnets parameter.
     Type: CommaDelimitedList
   BastionSG:
     Description: Security group used to whitelist for SSH access
@@ -165,7 +166,7 @@ Resources:
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', !Ref 'Subnets']
         InstanceType: !Ref 'BrokerInstanceType'
         MinInstancesPerAsg: 2
         ASGEventsTopic: !Ref 'ASGEventsTopic'
@@ -180,6 +181,7 @@ Resources:
         BastionSG: !Ref 'BastionSG'
         ParentStackName: !Ref 'AWS::StackName'
         VolumeNameTag: 'broker-data'
+        KinesisStackName: !Ref 'KinesisStackName'
     DependsOn: ['EBSBrokerVolume1','EBSBrokerVolume2','EBSBrokerVolume3']
   EBSBrokerVolume1:
     Type: 'AWS::CloudFormation::Stack'
@@ -229,7 +231,7 @@ Resources:
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', !Ref 'Subnets']
         InstanceType: !Ref 'ZookeeperInstanceType'
         ASGEventsTopic: !Ref 'ASGEventsTopic'
         MinInstancesPerAsg: 2
@@ -244,6 +246,7 @@ Resources:
         BastionSG: !Ref 'BastionSG'
         ParentStackName: !Ref 'AWS::StackName'
         VolumeNameTag: 'zk-data'
+        KinesisStackName: !Ref 'KinesisStackName'
     DependsOn: ['EBSZKVolume1','EBSZKVolume2','EBSZKVolume3']
   EBSZKVolume1:
     Type: 'AWS::CloudFormation::Stack'
@@ -293,7 +296,7 @@ Resources:
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
-        PrivateSubnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        PrivateSubnets: !Join [',', !Ref 'Subnets']
         InstanceType: !Ref 'ServicesInstanceType'
         EBSVolumeSize: !Ref 'ServicesDataVolumeSize'
         ASGMinSize: !Ref 'ServicesASGMinSize'
@@ -329,7 +332,7 @@ Resources:
         Cluster: !GetAtt 'ECSZK.Outputs.ClusterName'
         StackName: !Ref 'AWS::StackName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', !Ref 'Subnets']
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
@@ -337,6 +340,7 @@ Resources:
           'Fn::Sub': '${HostedZoneStackName}-ZoneName'
         DataVolumeMountPath: !GetAtt 'ECSZK.Outputs.EBSMountPath'
         InternalSG: !GetAtt 'InternalSecurityGroup.GroupId'
+        KinesisStackName: !Ref 'KinesisStackName'
     DependsOn: 'ECSZK'
 
   # The Kafka Cluster
@@ -348,7 +352,7 @@ Resources:
         Cluster: !GetAtt 'ECSBrokers.Outputs.ClusterName'
         StackName: !Ref 'AWS::StackName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', !Ref 'Subnets']
         ZookeeperConnectionString: !GetAtt 'Zookeeper.Outputs.ConnectionString'
         ZookeeperSecurityGroup: !GetAtt 'Zookeeper.Outputs.ClientZKSG'
         Project: !Ref 'Project'
@@ -358,6 +362,7 @@ Resources:
           'Fn::Sub': '${HostedZoneStackName}-ZoneName'
         DataVolumeMountPath: !GetAtt 'ECSBrokers.Outputs.EBSMountPath'
         InternalSG: !GetAtt 'InternalSecurityGroup.GroupId'
+        KinesisStackName: !Ref 'KinesisStackName'
     DependsOn: ['ECSBrokers', 'Zookeeper']
 
   # Security group to allow internal communications for this stack.

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -180,8 +180,8 @@ Resources:
         BastionSG: !Ref 'BastionSG'
         ParentStackName: !Ref 'AWS::StackName'
         VolumeNameTag: 'brokerdata'
-    DependsOn: ['EBSBrokers0','EBSBrokers1','EBSBrokers2']
-  EBSBrokers0:
+    DependsOn: ['EBSBrokerVolume1','EBSBrokerVolume2','EBSBrokerVolume3']
+  EBSBrokerVolume1:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: ./ebs.yaml
@@ -193,7 +193,8 @@ Resources:
         Team: !Ref Team
         Environment: !Ref Environment
         VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
-  EBSBrokers1:
+        BrokerId: '1'
+  EBSBrokerVolume2:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: ./ebs.yaml
@@ -205,7 +206,8 @@ Resources:
         Team: !Ref Team
         Environment: !Ref Environment
         VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
-  EBSBrokers2:
+        BrokerId: '2'
+  EBSBrokerVolume3:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: ./ebs.yaml
@@ -217,6 +219,7 @@ Resources:
         Team: !Ref Team
         Environment: !Ref Environment
         VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
+        BrokerId: '3'
   ECSZK:
     Type: 'AWS::CloudFormation::Stack'
     Properties:

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -157,6 +157,7 @@ Parameters:
     Description: Name of the CF stack used to create the Kinesis stream
 
 Resources:
+  # Create a 3-node ECS cluster for Kafka brokers
   ECSBrokers:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -164,9 +165,8 @@ Resources:
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [",", [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
         InstanceType: !Ref 'BrokerInstanceType'
-        EBSOptimizedInstance: 'true'
         MinInstancesPerAsg: 2
         ASGEventsTopic: !Ref 'ASGEventsTopic'
         Project: !Ref 'Project'
@@ -174,77 +174,118 @@ Resources:
         Environment: !Ref 'Environment'
         ClusterType: kafka
         HostedZoneId: !ImportValue
-          'Fn::Sub': "${HostedZoneStackName}-ZoneId"
+          'Fn::Sub': '${HostedZoneStackName}-ZoneId'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
         ParentStackName: !Ref 'AWS::StackName'
-        VolumeNameTag: 'brokerdata'
+        VolumeNameTag: 'broker-data'
     DependsOn: ['EBSBrokerVolume1','EBSBrokerVolume2','EBSBrokerVolume3']
   EBSBrokerVolume1:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: ./ebs.yaml
       Parameters:
-        DataVolumeSize: !Ref BrokerDataVolumeSize
+        DataVolumeSize: !Ref 'BrokerDataVolumeSize'
         DataVolumeIOPS: ''
         AvailabilityZone:  !Select [0, !Ref 'AvailabilityZones']
         Project: !Ref Project
         Team: !Ref Team
         Environment: !Ref Environment
-        VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
-        BrokerId: '1'
+        VolumeNameTag: !Sub ${AWS::StackName}-broker-data
+        NodeId: '1'
   EBSBrokerVolume2:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: ./ebs.yaml
       Parameters:
-        DataVolumeSize: !Ref BrokerDataVolumeSize
+        DataVolumeSize: !Ref 'BrokerDataVolumeSize'
         DataVolumeIOPS: ''
         AvailabilityZone: !Select [1, !Ref 'AvailabilityZones']
         Project: !Ref Project
         Team: !Ref Team
         Environment: !Ref Environment
-        VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
-        BrokerId: '2'
+        VolumeNameTag: !Sub '${AWS::StackName}-broker-data'
+        NodeId: '2'
   EBSBrokerVolume3:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: ./ebs.yaml
       Parameters:
-        DataVolumeSize: !Ref BrokerDataVolumeSize
+        DataVolumeSize: !Ref 'BrokerDataVolumeSize'
         DataVolumeIOPS: ''
         AvailabilityZone: !Select [2, !Ref 'AvailabilityZones']
         Project: !Ref Project
         Team: !Ref Team
         Environment: !Ref Environment
-        VolumeNameTag: !Sub ${AWS::StackName}-brokerdata
-        BrokerId: '3'
+        VolumeNameTag: !Sub '${AWS::StackName}-broker-data'
+        NodeId: '3'
+
+  # Create a 3-node ECS cluster for Zookeeper nodes
   ECSZK:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
-      TemplateURL: ./ecs.yaml
+      TemplateURL: ./ecs-without-ebs.yaml
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [",", [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
         InstanceType: !Ref 'ZookeeperInstanceType'
-        EBSOptimizedInstance: 'true'
-        ASGMinSize: 3
-        ASGMaxSize: 3
-        ASGDesiredCapacity: 3
-        RollingUpdateMinInService: !Ref 'RollingUpdateMinInService'
         ASGEventsTopic: !Ref 'ASGEventsTopic'
+        MinInstancesPerAsg: 2
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
         ClusterType: kafka
         HostedZoneId: !ImportValue
-          'Fn::Sub': "${HostedZoneStackName}-ZoneId"
-        EBSVolumeSize: !Ref 'ZookeeperDataVolumeSize'
+          'Fn::Sub': '${HostedZoneStackName}-ZoneId'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
+        ParentStackName: !Ref 'AWS::StackName'
+        VolumeNameTag: 'zk-data'
+    DependsOn: ['EBSZKVolume1','EBSZKVolume2','EBSZKVolume3']
+  EBSZKVolume1:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: ./ebs.yaml
+      Parameters:
+        DataVolumeSize: !Ref 'ZookeeperDataVolumeSize'
+        DataVolumeIOPS: ''
+        AvailabilityZone:  !Select [0, !Ref 'AvailabilityZones']
+        Project: !Ref Project
+        Team: !Ref Team
+        Environment: !Ref Environment
+        VolumeNameTag: !Sub '${AWS::StackName}-zk-data'
+        NodeId: '1'
+  EBSZKVolume2:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: ./ebs.yaml
+      Parameters:
+        DataVolumeSize: !Ref 'ZookeeperDataVolumeSize'
+        DataVolumeIOPS: ''
+        AvailabilityZone: !Select [1, !Ref 'AvailabilityZones']
+        Project: !Ref Project
+        Team: !Ref Team
+        Environment: !Ref Environment
+        VolumeNameTag: !Sub '${AWS::StackName}-zk-data'
+        NodeId: '2'
+  EBSZKVolume3:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: ./ebs.yaml
+      Parameters:
+        DataVolumeSize: !Ref 'ZookeeperDataVolumeSize'
+        DataVolumeIOPS: ''
+        AvailabilityZone: !Select [2, !Ref 'AvailabilityZones']
+        Project: !Ref Project
+        Team: !Ref Team
+        Environment: !Ref Environment
+        VolumeNameTag: !Sub '${AWS::StackName}-zk-data'
+        NodeId: '3'
+
+  # Create an autoscaling ECS cluster for services like Schema Registry, Kafka Connect and Rest Proxy
   Services:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -252,9 +293,8 @@ Resources:
       Parameters:
         KeyName: !Ref 'KeyName'
         VPCId: !Ref 'VPCId'
-        PrivateSubnets: !Join [",", [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        PrivateSubnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
         InstanceType: !Ref 'ServicesInstanceType'
-        EBSOptimizedInstance: 'true'
         EBSVolumeSize: !Ref 'ServicesDataVolumeSize'
         ASGMinSize: !Ref 'ServicesASGMinSize'
         ASGMaxSize: !Ref 'ServicesASGMaxSize'
@@ -280,6 +320,7 @@ Resources:
         BastionSG: !Ref 'BastionSG'
     DependsOn: 'ECSBrokers'
 
+  # The Zookeeper Cluster
   Zookeeper:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -288,16 +329,17 @@ Resources:
         Cluster: !GetAtt 'ECSZK.Outputs.ClusterName'
         StackName: !Ref 'AWS::StackName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [",", [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
         DomainName: !ImportValue
-          'Fn::Sub': "${HostedZoneStackName}-ZoneName"
+          'Fn::Sub': '${HostedZoneStackName}-ZoneName'
         DataVolumeMountPath: !GetAtt 'ECSZK.Outputs.EBSMountPath'
         InternalSG: !GetAtt 'InternalSecurityGroup.GroupId'
     DependsOn: 'ECSZK'
 
+  # The Kafka Cluster
   Brokers:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -306,18 +348,19 @@ Resources:
         Cluster: !GetAtt 'ECSBrokers.Outputs.ClusterName'
         StackName: !Ref 'AWS::StackName'
         VPCId: !Ref 'VPCId'
-        Subnets: !Join [",", [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
+        Subnets: !Join [',', [!Select [0, !Ref 'Subnets'], !Select [1, !Ref 'Subnets'], !Select [2, !Ref 'Subnets']]]
         ZookeeperConnectionString: !GetAtt 'Zookeeper.Outputs.ConnectionString'
         ZookeeperSecurityGroup: !GetAtt 'Zookeeper.Outputs.ClientZKSG'
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
         DomainName: !ImportValue
-          'Fn::Sub': "${HostedZoneStackName}-ZoneName"
+          'Fn::Sub': '${HostedZoneStackName}-ZoneName'
         DataVolumeMountPath: !GetAtt 'ECSBrokers.Outputs.EBSMountPath'
         InternalSG: !GetAtt 'InternalSecurityGroup.GroupId'
     DependsOn: ['ECSBrokers', 'Zookeeper']
 
+  # Security group to allow internal communications for this stack.
   InternalSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -325,7 +368,7 @@ Resources:
       GroupDescription: Allow connections from vpc
       SecurityGroupEgress:
         IpProtocol: -1
-        CidrIp: "0.0.0.0/0"
+        CidrIp: '0.0.0.0/0'
 
 Outputs:
   ClientKafkaSG:

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -168,12 +168,11 @@ Resources:
         VPCId: !Ref 'VPCId'
         Subnets: !Join [',', !Ref 'Subnets']
         InstanceType: !Ref 'BrokerInstanceType'
-        MinInstancesPerAsg: 2
+        MaxInstancesPerAsg: 2
         ASGEventsTopic: !Ref 'ASGEventsTopic'
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
-        ClusterType: kafka
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
@@ -234,11 +233,10 @@ Resources:
         Subnets: !Join [',', !Ref 'Subnets']
         InstanceType: !Ref 'ZookeeperInstanceType'
         ASGEventsTopic: !Ref 'ASGEventsTopic'
-        MinInstancesPerAsg: 2
+        MaxInstancesPerAsg: 2
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
-        ClusterType: kafka
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'

--- a/schema-registry/service.yaml
+++ b/schema-registry/service.yaml
@@ -34,7 +34,7 @@ Parameters:
   AppDesiredCount:
     Type: Number
     Description: Number of instances of the service to run
-    Default: '1'
+    Default: '2'
   UIDesiredCount:
     Type: Number
     Description: Number of instances of the service to run

--- a/schema-registry/service.yaml
+++ b/schema-registry/service.yaml
@@ -15,14 +15,22 @@ Parameters:
     Type: Number
     Description: Port the app runs on in the image
     Default: '8081'
-  Memory:
+  ServiceMemory:
     Type: Number
     Description: Soft memory on container
-    Default: '1280'
-  Cpu:
+    Default: '1024'
+  ServiceCpu:
     Type: Number
-    Description: cpu units on container
-    Default: '100'
+    Description: cpu unites on container
+    Default: '128'
+  JmxtransMemory:
+    Type: Number
+    Description: Soft memory on container
+    Default: '512'
+  JmxtransCpu:
+    Type: Number
+    Description: cpu unites on container
+    Default: '128'
   AppDesiredCount:
     Type: Number
     Description: Number of instances of the service to run
@@ -167,13 +175,13 @@ Resources:
       ContainerDefinitions:
         - Name: !Ref 'AppName'
           Image: loyaltyone/cp-schema-registry:0.1-beta
-          Cpu: !Ref 'Cpu'
+          Cpu: !Ref 'ServiceCpu'
           PortMappings:
             - ContainerPort: !Ref 'AppContainerPort'
               HostPort: 0
             - ContainerPort: !Ref 'JMXPort'
               HostPort: !Ref 'JMXPort'
-          MemoryReservation: !Ref 'Memory'
+          MemoryReservation: !Ref 'ServiceMemory'
           Essential: 'true'
           LogConfiguration:
             LogDriver: awslogs
@@ -198,8 +206,8 @@ Resources:
               Value: 3
         - Name: jmxtrans
           Image: loyaltyone/jmxtrans:0.1-beta
-          Cpu: '512'
-          MemoryReservation: '2048'
+          Cpu: !Ref 'JmxtransCpu'
+          MemoryReservation: !Ref 'JmxtransMemory'
           Links: [!Ref 'AppName']
           Environment:
             - Name: SECONDS_BETWEEN_RUNS
@@ -245,14 +253,14 @@ Resources:
       ContainerDefinitions:
         - Name: !Sub '${AppName}-ui'
           Image: !Sub 'landoop/schema-registry-ui'
-          Cpu: '100'
+          Cpu: !Ref 'ServiceCpu'
           PortMappings:
             - ContainerPort: 8000
               HostPort: 0
           Environment:
             - Name: SCHEMAREGISTRY_URL
               Value: !Sub 'https://${DNSRecordUI}'
-          MemoryReservation: '512'
+          MemoryReservation: !Ref 'ServiceMemory'
           Essential: 'true'
           LogConfiguration:
             LogDriver: awslogs

--- a/services-cluster.yaml
+++ b/services-cluster.yaml
@@ -50,12 +50,6 @@ Parameters:
     ]
     Default: m5.large
     ConstraintDescription: Must be a valid EC2 instance type
-  EBSOptimizedInstance:
-    Description: Enable EBS optimized flag. This will only work for instances that support it.
-    Type: String
-    AllowedValues: ['true', 'false']
-    Default: true
-    ConstraintDescription: Must be either 'true' or 'false'
   EBSVolumeSize:
     Description: Data volume size in GB for ECS instances. These will be exposed via EBSMountPath to containers.
     Type: Number
@@ -162,7 +156,6 @@ Resources:
         VPCId: !Ref 'VPCId'
         Subnets: !Join [",", [!Select [0, !Ref 'PrivateSubnets'], !Select [1, !Ref 'PrivateSubnets'], !Select [2, !Ref 'PrivateSubnets']]]
         InstanceType: !Ref 'InstanceType'
-        EBSOptimizedInstance: !Ref 'EBSOptimizedInstance'
         EBSVolumeSize: !Ref 'EBSVolumeSize'
         ASGMinSize: !Ref 'ASGMinSize'
         ASGMaxSize: !Ref 'ASGMaxSize'

--- a/services-cluster.yaml
+++ b/services-cluster.yaml
@@ -278,11 +278,6 @@ Outputs:
     Value: !Sub '${AWS::StackName}'
     Export:
       Name: !Sub '${AWS::StackName}-ClusterName'
-  AutoScalingGroupName:
-    Description: A reference to ECS AutoScaling Group Name
-    Value: !GetAtt 'ECS.Outputs.AutoScalingGroupName'
-    Export:
-      Name: !Sub '${AWS::StackName}-AutoScalingGroupName'
   ServiceAutoScalingRole:
     Description: A reference to ECS service auto scaling role
     Value: !GetAtt 'ECS.Outputs.ServiceAutoScalingRole'

--- a/services-cluster.yaml
+++ b/services-cluster.yaml
@@ -192,6 +192,7 @@ Resources:
         LoadBalancerCanonicalHostedZoneID: !GetAtt 'ELB.Outputs.LoadBalancerCanonicalHostedZoneID'
         LoadBalancerDNSName: !GetAtt 'ELB.Outputs.LoadBalancerDNS'
         ZookeeperConnectionString: !Ref 'ZookeeperConnectionString'
+        JMXPort: 8990
     DependsOn: 'ECS'
 
   RestProxy:
@@ -212,6 +213,7 @@ Resources:
         ZookeeperConnectionString: !Ref 'ZookeeperConnectionString'
         KafkaConnectionString: !Ref 'KafkaConnectionString'
         SchemaRegistryUrl: !GetAtt 'SchemaRegistry.Outputs.URL'
+        JMXPort: 8991
     DependsOn: 'SchemaRegistry'
 
   Connect:
@@ -232,6 +234,7 @@ Resources:
         LoadBalancerDNSName: !GetAtt 'ELB.Outputs.LoadBalancerDNS'
         ZookeeperConnectionString: !Ref 'ZookeeperConnectionString'
         KafkaConnectionString: !Ref 'KafkaConnectionString'
+        JMXPort: 8992
     DependsOn: 'SchemaRegistry'
 
 Outputs:

--- a/services-cluster.yaml
+++ b/services-cluster.yaml
@@ -172,6 +172,7 @@ Resources:
         AdditionalSecurityGroup: !Ref 'InternalSG'
         BastionSG: !Ref 'BastionSG'
         ELBSecurityGroupId: !GetAtt 'ELB.Outputs.ELBSecurityGroupId'
+        KinesisStackName: !Ref 'KinesisStackName'
     DependsOn: 'ELB'
 
   SchemaRegistry:

--- a/zookeeper/cluster.yaml
+++ b/zookeeper/cluster.yaml
@@ -67,6 +67,9 @@ Parameters:
   DomainName:
     Description: The domain name for Zookeeper hosts
     Type: String
+  KinesisStackName:
+    Type: String
+    Description: Name of the CF stack used to create the Kinesis stream
 
 Resources:
   ZKNodesLogGroup:
@@ -74,6 +77,18 @@ Resources:
     Properties:
       LogGroupName: !Sub '${StackName}/zk'
       RetentionInDays: 1
+  SubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn:
+      - ZKNodesLogGroup
+    Properties:
+      RoleArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Role-Arn
+      LogGroupName: !Ref 'ZKNodesLogGroup'
+      FilterPattern: ''
+      DestinationArn: !ImportValue
+        Fn::Sub: ${KinesisStackName}-Stream-Arn
+
   ClientZKSG:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:

--- a/zookeeper/cluster.yaml
+++ b/zookeeper/cluster.yaml
@@ -199,7 +199,7 @@ Resources:
         SecurityGroup: !Ref 'InternalZKSG'
         SubnetId: !Select [ 1, !Ref 'Subnets' ]
         DomainName: !Ref 'DomainName'
-    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG', 'ZKNode1']
+    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG']
   ZKNode3:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -220,7 +220,7 @@ Resources:
         SecurityGroup: !Ref 'InternalZKSG'
         SubnetId: !Select [ 2, !Ref 'Subnets' ]
         DomainName: !Ref 'DomainName'
-    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG', 'ZKNode2']
+    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG']
 
 Outputs:
   ClientZKSG:

--- a/zookeeper/cluster.yaml
+++ b/zookeeper/cluster.yaml
@@ -25,10 +25,6 @@ Parameters:
     Description: Zookeeper client port
     Type: Number
     Default: 2181
-  JMXPort:
-    Description: JMX Port to expose metrics on
-    Type: Number
-    Default: 8989
   PeerPortOne:
     Description: Zookeeper first peer port
     Type: Number
@@ -37,14 +33,22 @@ Parameters:
     Description: Zookeeper second peer port
     Type: Number
     Default: 3888
-  Cpu:
-    Description: Amount of CPU to reserve
+  ServiceCpu:
+    Description: CPU (1024 = 1 core)
     Type: Number
-    Default: 1024
-  Memory:
-    Description: Amount of Memory to reserve
+    Default: 896
+  ServiceMemory:
+    Description: Memory
     Type: Number
     Default: 4096
+  JmxtransCpu:
+    Description: CPU (1024 = 1 core)
+    Type: Number
+    Default: 128
+  JmxtransMemory:
+    Description: Memory
+    Type: Number
+    Default: 512
   InternalSG:
     Description: Security Group ID of the ECS Instances to allow JMX and client port ingress for this component
     Type: String
@@ -153,16 +157,16 @@ Resources:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       IpProtocol: tcp
-      FromPort: !Ref 'JMXPort'
-      ToPort: !Ref 'JMXPort'
+      FromPort: 8990
+      ToPort: 8992
       GroupId: !Ref 'InternalZKSG'
       SourceSecurityGroupId: !Ref 'InternalZKSG'
   InternalSGIngressJMXRule:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       IpProtocol: tcp
-      FromPort: !Ref 'JMXPort'
-      ToPort: !Ref 'JMXPort'
+      FromPort: 8990
+      ToPort: 8992
       GroupId: !Ref 'InternalZKSG'
       SourceSecurityGroupId: !Ref 'InternalSG'
   InternalSGClientIngressRule:
@@ -180,8 +184,10 @@ Resources:
       Parameters:
         Cluster: !Ref 'Cluster'
         StackName: !Ref 'StackName'
-        Cpu: !Ref 'Cpu'
-        Memory: !Ref 'Memory'
+        ServiceCpu: !Ref 'ServiceCpu'
+        ServiceMemory: !Ref 'ServiceMemory'
+        JmxtransCpu: !Ref 'JmxtransCpu'
+        JmxtransMemory: !Ref 'JmxtransMemory'
         DataVolumeMountPath: !Ref 'DataVolumeMountPath'
         ServerId: 1
         ServerName: !Sub '${StackName}-zk1'
@@ -193,6 +199,7 @@ Resources:
         SecurityGroup: !Ref 'InternalZKSG'
         SubnetId: !Select [ 0, !Ref 'Subnets' ]
         DomainName: !Ref 'DomainName'
+        JMXPort: 8990
     DependsOn: ['ZKNodesLogGroup', 'InternalZKSG']
   ZKNode2:
     Type: 'AWS::CloudFormation::Stack'
@@ -201,8 +208,10 @@ Resources:
       Parameters:
         Cluster: !Ref 'Cluster'
         StackName: !Ref 'StackName'
-        Cpu: !Ref 'Cpu'
-        Memory: !Ref 'Memory'
+        ServiceCpu: !Ref 'ServiceCpu'
+        ServiceMemory: !Ref 'ServiceMemory'
+        JmxtransCpu: !Ref 'JmxtransCpu'
+        JmxtransMemory: !Ref 'JmxtransMemory'
         DataVolumeMountPath: !Ref 'DataVolumeMountPath'
         ServerId: 2
         ServerName: !Sub '${StackName}-zk2'
@@ -214,6 +223,7 @@ Resources:
         SecurityGroup: !Ref 'InternalZKSG'
         SubnetId: !Select [ 1, !Ref 'Subnets' ]
         DomainName: !Ref 'DomainName'
+        JMXPort: 8991
     DependsOn: ['ZKNodesLogGroup', 'InternalZKSG']
   ZKNode3:
     Type: 'AWS::CloudFormation::Stack'
@@ -222,8 +232,10 @@ Resources:
       Parameters:
         Cluster: !Ref 'Cluster'
         StackName: !Ref 'StackName'
-        Cpu: !Ref 'Cpu'
-        Memory: !Ref 'Memory'
+        ServiceCpu: !Ref 'ServiceCpu'
+        ServiceMemory: !Ref 'ServiceMemory'
+        JmxtransCpu: !Ref 'JmxtransCpu'
+        JmxtransMemory: !Ref 'JmxtransMemory'
         DataVolumeMountPath: !Ref 'DataVolumeMountPath'
         ServerId: 3
         ServerName: !Sub '${StackName}-zk3'
@@ -235,6 +247,7 @@ Resources:
         SecurityGroup: !Ref 'InternalZKSG'
         SubnetId: !Select [ 2, !Ref 'Subnets' ]
         DomainName: !Ref 'DomainName'
+        JMXPort: 8992
     DependsOn: ['ZKNodesLogGroup', 'InternalZKSG']
 
 Outputs:

--- a/zookeeper/service.yaml
+++ b/zookeeper/service.yaml
@@ -10,14 +10,22 @@ Parameters:
   StackName:
     Description: The Parent Stack Name
     Type: String
-  Cpu:
+  ServiceCpu:
     Description: CPU (1024 = 1 core)
     Type: Number
-    Default: 1024
-  Memory:
+    Default: 896
+  ServiceMemory:
     Description: Memory
     Type: Number
     Default: 4096
+  JmxtransCpu:
+    Description: CPU (1024 = 1 core)
+    Type: Number
+    Default: 128
+  JmxtransMemory:
+    Description: Memory
+    Type: Number
+    Default: 512
   DataVolumeMountPath:
     Description: Path to directory for mounting data
     Type: String
@@ -72,8 +80,8 @@ Resources:
       ContainerDefinitions:
       - Name: zookeeper
         Image: loyaltyone/cp-zookeeper:0.1-beta
-        Cpu: !Ref 'Cpu'
-        MemoryReservation: !Ref 'Memory'
+        Cpu: !Ref 'ServiceCpu'
+        MemoryReservation: !Ref 'ServiceMemory'
         User: root
         DockerLabels:
           'discovery.service.name': !Ref 'ServerName'
@@ -118,8 +126,8 @@ Resources:
             awslogs-stream-prefix: !Sub 'zk${ServerId}'
       - Name: jmxtrans
         Image: loyaltyone/jmxtrans:0.1-beta
-        Cpu: '512'
-        MemoryReservation: '2048'
+        Cpu: !Ref 'JmxtransCpu'
+        MemoryReservation: !Ref 'JmxtransMemory'
         Environment:
           - Name: SECONDS_BETWEEN_RUNS
             Value: 60


### PR DESCRIPTION
##### Description

There are issues with data loss that can occur due to rolling deployments or with multiple node failovers if the EBS volume storing data gets deleted on termination.

The implementation now uses one autoscaling group per availability zone and spins up data volumes in those availability zones for ECS instances to attach to. The volumes will not terminate when an instance fails over allowing it to re-attach and minimize the amount of data it has to synchronize for the topic partitions.

Also, added some improvements for reducing number of log streams and wiring up Kinesis subscription filter for the Log Groups.