### PR TITLE
Ssl

### DIFF
--- a/deploy-master-stack
+++ b/deploy-master-stack
@@ -46,6 +46,7 @@ aws cloudformation package --template-file master-template.yaml \
 
 echo "Deploying master template"
 params=$(jq -r '.Parameters | to_entries | map("\(.key)=\(.value|tostring)")|.[]' ${stack_config} | tr '\n' ' ')
+echo "$params"
 aws cloudformation deploy --template-file master.yaml --stack-name "${ENV:-dev}"-${stack_suffix} \
     --capabilities CAPABILITY_IAM --parameter-overrides ${params}
 

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -51,9 +51,6 @@ Parameters:
   CertificateOrganizationUnit:
     Description: The organization unit to use in the certificate
     Type: String
-  IssuingCaS3Path:
-    Description: The S3 path for the Issuing CA's certificate
-    Type: String
 
   # Instances
   InstanceType:
@@ -248,7 +245,6 @@ Resources:
               'route53:ListHostedZonesByName',
               's3:PutObject',
               's3:AbortMultipartUpload',
-              's3:GetObject',
               'ssm:DescribeAssociation',
               'ssm:GetDeployablePatchSnapshotForInstance',
               'ssm:GetDocument',
@@ -662,10 +658,6 @@ Resources:
 
                 aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} \
                   --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/broker.crt
-
-                # Fetch issuing CA root cert
-                aws s3 cp ${IssuingCaS3Path} ${EBSMountPath}/ssl/issuing_ca.pem --region ${AWS::Region}
-                cat ${EBSMountPath}/ssl/issuing_ca.pem >> ${EBSMountPath}/ssl/ca.crt
 
                 # Create PKCS12 format to allow importing into keystore
                 openssl pkcs12 -export \

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -24,6 +24,11 @@ Parameters:
     Description: Security group used to whitelist elb access
     Type: String
     Default: ''
+  DomainName:
+    Description: >
+      The domain under which the Kafka and Zookeeper nodes will register their advertised address.
+      Note: This is the HostedZoneName without the period suffix.
+    Type: String
 
   # Instances
   InstanceType:
@@ -75,6 +80,17 @@ Parameters:
   KinesisStackName:
     Type: String
     Description: Name of the CF stack used to create the Kinesis stream
+  SetupBrokerCerts:
+    Type: String
+    Default: 'no'
+    AllowedValues: ['yes','no']
+    Description: "If the cluster is being used for Kafka brokers use 'yes'; otherwise 'no'."
+  NodeCount:
+    Type: Number
+    MinValue: 1
+    Default: 3
+    Description: The total number of nodes in the cluster.
+    ConstraintDescription: Must be a value >= 1
 
   # Parameter to force a rolling deployment
   RollingDeploymentVersion:
@@ -117,18 +133,18 @@ Mappings:
   # These are the latest ECS optimized AMIs as of March 2018:
   #
   #   amzn-ami-2017.09.l-amazon-ecs-optimized
-  #   ECS agent:    1.17.3
+  #   ECS agent:    1.18.0
   #   Docker:       17.12.1-ce
-  #   ecs-init:     1.17.3-1
+  #   ecs-init:     1.18.0-1
   #
   # You can find the latest available on this page of our documentation:
   # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
   # (note the AMI identifier is region specific)
   AWSRegionToAMI:
     us-east-1:
-      AMI: ami-aff65ad2
+      AMI: ami-5253c32d
     ca-central-1:
-      AMI: ami-897ff9ed
+      AMI: ami-da6cecbe
 
 Resources:
   ECSLogGroup:
@@ -548,7 +564,12 @@ Resources:
 
                 exec >> /var/log/user-data.log 2>&1
 
-                echo "Beginning setup of SSL configuration"
+                if [[ "${SetupBrokerCerts}" == "no" ]]; then
+                  echo "Skipping Broker SSL configuration."
+                  exit 0
+                fi
+
+                echo "Beginning Broker SSL configuration"
 
                 cd /tmp/
                 curl -O https://bootstrap.pypa.io/get-pip.py
@@ -557,13 +578,17 @@ Resources:
 
                 mkdir -p ${EBSMountPath}/ssl
 
-                domain_name=${ParentStackName}-broker.kafka.com
-                # get ca cert
+                # Get CA certificate
                 aws acm-pca get-certificate-authority-certificate --region ${AWS::Region} --certificate-authority-arn ${PrivateCaArn}  | jq -r '.Certificate' > ${EBSMountPath}/ssl/ca.crt
 
-                # generate private key
-                # should change CN to param
+                # Generate SAN
+                alt_names=""
+                for i in $(seq 1 ${NodeCount}); do
+                  alt_names=$(echo -e "${!alt_names}\nDNS.${!i} = ${ParentStackName}-broker${!i}.${DomainName}")
+                done
+                alt_names=$(echo "$alt_names" | sed -e '/^$/d')
 
+                # Generate private key
                 openssl req -new -sha256 -nodes -out ${EBSMountPath}/ssl/broker.csr -newkey rsa:2048 -keyout ${EBSMountPath}/ssl/broker.key -config <(
                 cat <<-EOF
                 [req]
@@ -574,20 +599,18 @@ Resources:
                 distinguished_name = dn
 
                 [ dn ]
-                C=CA
-                ST=Ontario
-                L=Toronto
-                O=LoyaltyOne, Co.
-                OU=IT
-                CN = $domain_name
+                C = CA
+                ST = Ontario
+                L = Toronto
+                O = LoyaltyOne, Co.
+                OU = IT
+                CN = ${ParentStackName}-broker.${DomainName}
 
                 [ req_ext ]
                 subjectAltName = @alt_names
 
                 [ alt_names ]
-                DNS.1 = broker1.internal.loyalty.com
-                DNS.2 = broker2.internal.loyalty.com
-                DNS.3 = broker3.internal.loyalty.com
+                $alt_names
                 EOF
                 )
 

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -207,6 +207,7 @@ Resources:
               'route53:ListHostedZonesByName',
               's3:PutObject',
               's3:AbortMultipartUpload',
+              's3:GetObject',
               'ssm:DescribeAssociation',
               'ssm:GetDeployablePatchSnapshotForInstance',
               'ssm:GetDocument',
@@ -558,12 +559,12 @@ Resources:
 
                 domain_name=${ParentStackName}-broker.kafka.com
                 # get ca cert
-                aws acm-pca get-certificate-authority-certificate --region ${AWS::Region} --certificate-authority-arn ${PrivateCaArn}  | jq -r '.Certificate' > ${EBSMountPath}/ssl/ca_cert.crt
+                aws acm-pca get-certificate-authority-certificate --region ${AWS::Region} --certificate-authority-arn ${PrivateCaArn}  | jq -r '.Certificate' > ${EBSMountPath}/ssl/ca.crt
 
                 # generate private key
                 # should change CN to param
 
-                openssl req -new -sha256 -nodes -out ${EBSMountPath}/ssl/broker.internal.loyalty.com.csr -newkey rsa:2048 -keyout ${EBSMountPath}/ssl/broker.internal.loyalty.com.key -config <(
+                openssl req -new -sha256 -nodes -out ${EBSMountPath}/ssl/broker.csr -newkey rsa:2048 -keyout ${EBSMountPath}/ssl/broker.key -config <(
                 cat <<-EOF
                 [req]
                 default_bits = 2048
@@ -593,7 +594,7 @@ Resources:
                 # have aws private ca issue cert
                 certificate_arn=$(aws acm-pca issue-certificate --region ${AWS::Region} \
                   --certificate-authority-arn ${PrivateCaArn} \
-                  --csr file://${EBSMountPath}/ssl/broker.internal.loyalty.com.csr \
+                  --csr file://${EBSMountPath}/ssl/broker.csr \
                   --signing-algorithm "SHA256WITHRSA" \
                   --validity Value=365,Type="DAYS" \
                   --idempotency-token 1234 | jq -r '.CertificateArn')
@@ -602,7 +603,14 @@ Resources:
                 sleep 30
                 echo "cert arn:" + $certificate_arn
 
-                aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/broker_cert.crt
+                aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/broker.crt
+
+                # fetch loissuingca root cert
+                aws s3 cp s3://dev-kafka-artifacts/certs/loissuingca.pem ${EBSMountPath}/ssl/loissuingca.pem --region us-east-1
+                cat ${EBSMountPath}/ssl/loissuingca.pem >> ${EBSMountPath}/ssl/ca.crt
+
+                # create PKCS12 format to allow importing into keystore
+                openssl pkcs12 -export -in ${EBSMountPath}/ssl/broker.crt -inkey ${EBSMountPath}/ssl/broker.key -out ${EBSMountPath}/ssl/broker.p12 -name broker -CAfile ${EBSMountPath}/ssl/ca.crt -caname root -password pass:changeme
           commands:
             01_setup_tags:
               command: '/usr/local/share/setup-tags'

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -30,6 +30,31 @@ Parameters:
       Note: This is the HostedZoneName without the period suffix.
     Type: String
 
+  # Certificate information
+  KafkaKeyPass:
+    Description: Password for the Kafka keystore
+    Type: String
+    NoEcho: true
+    Default: ''
+  CertificateCountry:
+    Description: The country to use in the certificate (usually 2 character country code like CA)
+    Type: String
+  CertificateState:
+    Description: The state or province to use in the certificate
+    Type: String
+  CertificateLocalityName:
+    Description: The locality name to use in the certificate
+    Type: String
+  CertificateOrganizationName:
+    Description: The organization name to use in the certificate
+    Type: String
+  CertificateOrganizationUnit:
+    Description: The organization unit to use in the certificate
+    Type: String
+  IssuingCaS3Path:
+    Description: The S3 path for the Issuing CA's certificate
+    Type: String
+
   # Instances
   InstanceType:
     Description: Which instance type should we use to build the ECS cluster?
@@ -608,11 +633,11 @@ Resources:
                 distinguished_name = dn
 
                 [ dn ]
-                C = CA
-                ST = Ontario
-                L = Toronto
-                O = LoyaltyOne, Co.
-                OU = IT
+                C = ${CertificateCountry}
+                ST = ${CertificateState}
+                L = ${CertificateLocalityName}
+                O = ${CertificateOrganizationName}
+                OU = ${CertificateOrganizationUnit}
                 CN = ${ParentStackName}-broker.${DomainName}
 
                 [ req_ext ]
@@ -623,7 +648,7 @@ Resources:
                 EOF
                 )
 
-                # have aws private ca issue cert
+                # Have aws private ca issue cert
                 certificate_arn=$(aws acm-pca issue-certificate --region ${AWS::Region} \
                   --certificate-authority-arn ${PrivateCaArn} \
                   --csr file://${EBSMountPath}/ssl/broker.csr \
@@ -635,14 +660,21 @@ Resources:
                 sleep 30
                 echo "cert arn:" + $certificate_arn
 
-                aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/broker.crt
+                aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} \
+                  --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/broker.crt
 
-                # fetch loissuingca root cert
-                aws s3 cp s3://dev-kafka-artifacts/certs/loissuingca.pem ${EBSMountPath}/ssl/loissuingca.pem --region us-east-1
-                cat ${EBSMountPath}/ssl/loissuingca.pem >> ${EBSMountPath}/ssl/ca.crt
+                # Fetch issuing CA root cert
+                aws s3 cp ${IssuingCaS3Path} ${EBSMountPath}/ssl/issuing_ca.pem --region ${AWS::Region}
+                cat ${EBSMountPath}/ssl/issuing_ca.pem >> ${EBSMountPath}/ssl/ca.crt
 
-                # create PKCS12 format to allow importing into keystore
-                openssl pkcs12 -export -in ${EBSMountPath}/ssl/broker.crt -inkey ${EBSMountPath}/ssl/broker.key -out ${EBSMountPath}/ssl/broker.p12 -name broker -CAfile ${EBSMountPath}/ssl/ca.crt -caname root -password pass:changeme
+                # Create PKCS12 format to allow importing into keystore
+                openssl pkcs12 -export \
+                  -in ${EBSMountPath}/ssl/broker.crt \
+                  -inkey ${EBSMountPath}/ssl/broker.key \
+                  -out ${EBSMountPath}/ssl/broker.p12 \
+                  -name broker -CAfile ${EBSMountPath}/ssl/ca.crt \
+                  -caname root \
+                  -password pass:${KafkaKeyPass}
           commands:
             01_setup_tags:
               command: '/usr/local/share/setup-tags'

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -588,8 +588,17 @@ Resources:
                 done
                 alt_names=$(echo "$alt_names" | sed -e '/^$/d')
 
+                echo "The SAN configuration is:"
+                echo -e "$alt_names"
+
                 # Generate private key
-                openssl req -new -sha256 -nodes -out ${EBSMountPath}/ssl/broker.csr -newkey rsa:2048 -keyout ${EBSMountPath}/ssl/broker.key -config <(
+                openssl req -new \
+                  -sha256 \
+                  -nodes \
+                  -out ${EBSMountPath}/ssl/broker.csr \
+                  -newkey rsa:2048 \
+                  -keyout ${EBSMountPath}/ssl/broker.key \
+                  -config <(
                 cat <<-EOF
                 [req]
                 default_bits = 2048

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -109,6 +109,10 @@ Parameters:
     Type: String
     Description: Tag for identifying the data volume to use for the ECS instances
 
+  PrivateCaArn:
+    Type: String
+    Description: the ARN of the Private CA that signs the broker certificate
+
 Mappings:
   # These are the latest ECS optimized AMIs as of March 2018:
   #
@@ -220,7 +224,10 @@ Resources:
               'ec2:DescribeTags',
               'ec2:CreateTags',
               'ec2:DescribeVolumes',
-              'ec2:AttachVolume'
+              'ec2:AttachVolume',
+              'acm-pca:GetCertificate',
+              'acm-pca:GetCertificateAuthorityCertificate',
+              'acm-pca:IssueCertificate'
             ]
             Effect: Allow
             Resource: '*'
@@ -531,11 +538,78 @@ Resources:
                 node_id=$(aws ec2 describe-volumes --volume-ids $volume_id | jq -r '.Volumes[0].Tags[] | select(.Key == "NodeId").Value')
                 echo "Setting up InstanceId=$instance_id for tag NodeId=$node_id..."
                 aws ec2 create-tags --resources $instance_id --tags Key=NodeId,Value=$node_id
+            '/usr/local/share/setup-ssl-certs':
+              mode: '000744'
+              owner: root
+              group: root
+              content: !Sub |
+                #!/bin/bash -e
+
+                exec >> /var/log/user-data.log 2>&1
+
+                echo "Beginning setup of SSL configuration"
+
+                cd /tmp/
+                curl -O https://bootstrap.pypa.io/get-pip.py
+                python /tmp/get-pip.py
+                /usr/local/bin/pip install awscli --upgrade --user
+
+                mkdir -p ${EBSMountPath}/ssl
+
+                domain_name=${ParentStackName}-broker.kafka.com
+                # get ca cert
+                aws acm-pca get-certificate-authority-certificate --region ${AWS::Region} --certificate-authority-arn ${PrivateCaArn}  | jq -r '.Certificate' > ${EBSMountPath}/ssl/ca_cert.crt
+
+                # generate private key
+                # should change CN to param
+
+                openssl req -new -sha256 -nodes -out ${EBSMountPath}/ssl/broker.internal.loyalty.com.csr -newkey rsa:2048 -keyout ${EBSMountPath}/ssl/broker.internal.loyalty.com.key -config <(
+                cat <<-EOF
+                [req]
+                default_bits = 2048
+                prompt = no
+                default_md = sha256
+                req_extensions = req_ext
+                distinguished_name = dn
+
+                [ dn ]
+                C=CA
+                ST=Ontario
+                L=Toronto
+                O=LoyaltyOne, Co.
+                OU=IT
+                CN = $domain_name
+
+                [ req_ext ]
+                subjectAltName = @alt_names
+
+                [ alt_names ]
+                DNS.1 = broker1.internal.loyalty.com
+                DNS.2 = broker2.internal.loyalty.com
+                DNS.3 = broker3.internal.loyalty.com
+                EOF
+                )
+
+                # have aws private ca issue cert
+                certificate_arn=$(aws acm-pca issue-certificate --region ${AWS::Region} \
+                  --certificate-authority-arn ${PrivateCaArn} \
+                  --csr file://${EBSMountPath}/ssl/broker.internal.loyalty.com.csr \
+                  --signing-algorithm "SHA256WITHRSA" \
+                  --validity Value=365,Type="DAYS" \
+                  --idempotency-token 1234 | jq -r '.CertificateArn')
+
+                echo "Sleeping for 30 seconds while cert is issued"
+                sleep 30
+                echo "cert arn:" + $certificate_arn
+
+                aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/broker_cert.crt
           commands:
             01_setup_tags:
               command: '/usr/local/share/setup-tags'
             02_setup_ebs_volume:
               command: '/usr/local/share/setup-data-volume'
+            03_setup_ssl:
+              command: '/usr/local/share/setup-ssl-certs'
             03_add_instance_to_cluster:
               # Let ecs agent know which cluster to join
               command: !Sub 'echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config'
@@ -632,6 +706,7 @@ Resources:
               mode: '000644'
               owner: root
               group: root
+
   ECSAutoScalingGroup0:
     DependsOn: 'ECSLogGroup'
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -669,7 +744,7 @@ Resources:
           PropagateAtLaunch: true
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT15M
+        Timeout: PT25M
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MinInstancesInService: 1
@@ -719,7 +794,7 @@ Resources:
           PropagateAtLaunch: true
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT15M
+        Timeout: PT25M
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MinInstancesInService: 1
@@ -769,7 +844,7 @@ Resources:
           PropagateAtLaunch: true
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT15M
+        Timeout: PT25M
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MinInstancesInService: 1

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -120,18 +120,18 @@ Mappings:
   # These are the latest ECS optimized AMIs as of March 2018:
   #
   #   amzn-ami-2017.09.l-amazon-ecs-optimized
-  #   ECS agent:    1.17.3
+  #   ECS agent:    1.18.0
   #   Docker:       17.12.1-ce
-  #   ecs-init:     1.17.3-1
+  #   ecs-init:     1.18.0-1
   #
   # You can find the latest available on this page of our documentation:
   # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
   # (note the AMI identifier is region specific)
   AWSRegionToAMI:
     us-east-1:
-      AMI: ami-aff65ad2
+      AMI: ami-5253c32d
     ca-central-1:
-      AMI: ami-897ff9ed
+      AMI: ami-da6cecbe
 
 Conditions:
   IsClusterTypeService: !Equals [!Ref 'ClusterType', 'service']

--- a/kafka/bootstrap
+++ b/kafka/bootstrap
@@ -19,12 +19,25 @@ then
 fi
 echo "KAFKA_BROKER_RACK: ${KAFKA_BROKER_RACK}"
 
-if [ -z "${KAFKA_SSL_DIR}" ];
+if [ -n "${KAFKA_SSL_DIR}" ];
 then
-    # If SSL directory env variable is set, generate keystore and truststore
-    keytool -import -alias ca -file ${KAFKA_SSL_DIR}/ca_cert.crt -keystore ${KAFKA_SSL_DIR}/kafka.truststore.jks -storepass ${KAFKA_TRUST_PASS} -noprompt
-    keytool -import -alias broker -file ${KAFKA_SSL_DIR}/broker_key.key -keystore ${KAFKA_SSL_DIR}/kafka.keystore.jks -storepass ${KAFKA_KEY_PASS} -noprompt
-    keytool -import -alias broker -file ${KAFKA_SSL_DIR}/broker_cert.crt -keystore ${KAFKA_SSL_DIR}/kafka.truststore.jks -storepass ${KAFKA_TRUST_PASS} -noprompt
+  # If SSL directory env variable is set, generate keystore and truststore
+  if [ ! -f ${KAFKA_SSL_DIR}/kafka.truststore.jks ];
+  then
+    # If truststore doesn't exist, generate truststore
+    keytool -import -alias ca -file ${KAFKA_SSL_DIR}/ca.crt -keystore ${KAFKA_SSL_DIR}/kafka.truststore.jks -storepass ${KAFKA_SSL_TRUSTSTORE_PASSWORD} -noprompt
+    keytool -import -alias broker -file ${KAFKA_SSL_DIR}/broker.crt -keystore ${KAFKA_SSL_DIR}/kafka.truststore.jks -storepass ${KAFKA_SSL_TRUSTSTORE_PASSWORD} -noprompt
+    cp ${KAFKA_SSL_DIR}/kafka.truststore.jks /etc/kafka/secrets/kafka.truststore.jks
+  fi
+  if [ ! -f ${KAFKA_SSL_DIR}/kafka.keystore.jks ];
+  then
+    # IF keystore doesn't exist, generate keystore
+    keytool -importkeystore -deststorepass ${KAFKA_SSL_KEYSTORE_PASSWORD} -destkeypass ${KAFKA_SSL_KEY_PASSWORD} -destkeystore ${KAFKA_SSL_DIR}/kafka.keystore.jks -srckeystore ${KAFKA_SSL_DIR}/broker.p12 -srcstoretype PKCS12 -srcstorepass changeme -alias broker
+    cp ${KAFKA_SSL_DIR}/kafka.keystore.jks /etc/kafka/secrets/kafka.keystore.jks
+  fi
+  echo ${KAFKA_SSL_TRUSTSTORE_PASSWORD} > /etc/kafka/secrets/broker_truststore_creds
+  echo ${KAFKA_SSL_KEYSTORE_PASSWORD} > /etc/kafka/secrets/broker_keystore_creds
+  echo ${KAFKA_SSL_KEY_PASSWORD} > /etc/kafka/secrets/broker_sslkey_creds
 fi
 
 exec "$@"

--- a/kafka/bootstrap
+++ b/kafka/bootstrap
@@ -19,4 +19,12 @@ then
 fi
 echo "KAFKA_BROKER_RACK: ${KAFKA_BROKER_RACK}"
 
+if [ -z "${KAFKA_SSL_DIR}" ];
+then
+    # If SSL directory env variable is set, generate keystore and truststore
+    keytool -import -alias ca -file ${KAFKA_SSL_DIR}/ca_cert.crt -keystore ${KAFKA_SSL_DIR}/kafka.truststore.jks -storepass ${KAFKA_TRUST_PASS} -noprompt
+    keytool -import -alias broker -file ${KAFKA_SSL_DIR}/broker_key.key -keystore ${KAFKA_SSL_DIR}/kafka.keystore.jks -storepass ${KAFKA_KEY_PASS} -noprompt
+    keytool -import -alias broker -file ${KAFKA_SSL_DIR}/broker_cert.crt -keystore ${KAFKA_SSL_DIR}/kafka.truststore.jks -storepass ${KAFKA_TRUST_PASS} -noprompt
+fi
+
 exec "$@"

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -72,7 +72,16 @@ Parameters:
   KinesisStackName:
     Type: String
     Description: Name of the CF stack used to create the Kinesis stream
-
+  KafkaKeyPass:
+    Description: Password for the kafka keystore
+    Type: String
+    NoEcho: true
+    Default: ''
+  KafkaTrustPass:
+    Description: Password for the kafka keystore
+    Type: String
+    NoEcho: true
+    Default: ''
 Resources:
   BrokersLogGroup:
     Type: 'AWS::Logs::LogGroup'
@@ -188,6 +197,8 @@ Resources:
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 0, !Ref 'Subnets' ]
         JMXPort: 8990
+        KafkaKeyPass: !Ref 'KafkaKeyPass'
+        KafkaTrustPass: !Ref 'KafkaTrustPass'
     DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
   Broker2:
     Type: 'AWS::CloudFormation::Stack'
@@ -211,6 +222,8 @@ Resources:
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 1, !Ref 'Subnets' ]
         JMXPort: 8991
+        KafkaKeyPass: !Ref 'KafkaKeyPass'
+        KafkaTrustPass: !Ref 'KafkaTrustPass'
     DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
   Broker3:
     Type: 'AWS::CloudFormation::Stack'
@@ -234,6 +247,8 @@ Resources:
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 2, !Ref 'Subnets' ]
         JMXPort: 8992
+        KafkaKeyPass: !Ref 'KafkaKeyPass'
+        KafkaTrustPass: !Ref 'KafkaTrustPass'
     DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
 
 Outputs:

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -71,7 +71,9 @@ Parameters:
     Default: dev
     ConstraintDescription: Must be one of dev|sandbox|prod.
   DomainName:
-    Description: The domain name for Kafka brokers
+    Description: >
+      The domain under which the broker will register its advertised address.
+      Note: This is the HostedZoneName without the period suffix.
     Type: String
   KinesisStackName:
     Type: String
@@ -150,15 +152,15 @@ Resources:
         IpProtocol: -1
         CidrIp: "0.0.0.0/0"
     DependsOn: 'ClientKafkaSG'
-#  InternalKafkaSGIngress:
-#    Type: 'AWS::EC2::SecurityGroupIngress'
-#    Properties:
-#      IpProtocol: tcp
-#      FromPort: !Ref 'ClientPort'
-#      ToPort: !Ref 'ClientPort'
-#      GroupId: !Ref 'InternalKafkaSG'
-#      SourceSecurityGroupId: !Ref 'InternalKafkaSG'
-#    DependsOn: 'InternalKafkaSG'
+  InternalKafkaSGIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      IpProtocol: tcp
+      FromPort: !Ref 'ClientPort'
+      ToPort: !Ref 'ClientPort'
+      GroupId: !Ref 'InternalKafkaSG'
+      SourceSecurityGroupId: !Ref 'InternalKafkaSG'
+    DependsOn: 'InternalKafkaSG'
   InternalSSLKafkaSGIngress:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
@@ -290,3 +292,10 @@ Outputs:
       - Broker1: !GetAtt 'Broker1.Outputs.ConnectionString'
         Broker2: !GetAtt 'Broker2.Outputs.ConnectionString'
         Broker3: !GetAtt 'Broker3.Outputs.ConnectionString'
+  SSLConnectionString:
+    Description: SSL connection string to connect to kafka brokers
+    Value: !Sub
+      - '${Broker1},${Broker2},${Broker3}'
+      - Broker1: !GetAtt 'Broker1.Outputs.SSLConnectionString'
+        Broker2: !GetAtt 'Broker2.Outputs.SSLConnectionString'
+        Broker3: !GetAtt 'Broker3.Outputs.SSLConnectionString'

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -150,15 +150,15 @@ Resources:
         IpProtocol: -1
         CidrIp: "0.0.0.0/0"
     DependsOn: 'ClientKafkaSG'
-  InternalKafkaSGIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      IpProtocol: tcp
-      FromPort: !Ref 'ClientPort'
-      ToPort: !Ref 'ClientPort'
-      GroupId: !Ref 'InternalKafkaSG'
-      SourceSecurityGroupId: !Ref 'InternalKafkaSG'
-    DependsOn: 'InternalKafkaSG'
+#  InternalKafkaSGIngress:
+#    Type: 'AWS::EC2::SecurityGroupIngress'
+#    Properties:
+#      IpProtocol: tcp
+#      FromPort: !Ref 'ClientPort'
+#      ToPort: !Ref 'ClientPort'
+#      GroupId: !Ref 'InternalKafkaSG'
+#      SourceSecurityGroupId: !Ref 'InternalKafkaSG'
+#    DependsOn: 'InternalKafkaSG'
   InternalSSLKafkaSGIngress:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -25,6 +25,10 @@ Parameters:
     Description: Kafka client port
     Type: Number
     Default: 9092
+  ClientSSLPort:
+    Description: Kafka client SSL port
+    Type: Number
+    Default: 9093
   ZookeeperConnectionString:
     Description: Connection string for Zookeeper Cluster
     Type: String
@@ -128,6 +132,10 @@ Resources:
           IpProtocol: tcp
           FromPort: !Ref 'ClientPort'
           ToPort: !Ref 'ClientPort'
+        - SourceSecurityGroupId: !Ref 'ClientKafkaSG'
+          IpProtocol: tcp
+          FromPort: !Ref 'ClientSSLPort'
+          ToPort: !Ref 'ClientSSLPort'
       VpcId: !Ref 'VPCId'
       Tags:
         - Key: Project
@@ -148,6 +156,15 @@ Resources:
       IpProtocol: tcp
       FromPort: !Ref 'ClientPort'
       ToPort: !Ref 'ClientPort'
+      GroupId: !Ref 'InternalKafkaSG'
+      SourceSecurityGroupId: !Ref 'InternalKafkaSG'
+    DependsOn: 'InternalKafkaSG'
+  InternalSSLKafkaSGIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      IpProtocol: tcp
+      FromPort: !Ref 'ClientSSLPort'
+      ToPort: !Ref 'ClientSSLPort'
       GroupId: !Ref 'InternalKafkaSG'
       SourceSecurityGroupId: !Ref 'InternalKafkaSG'
     DependsOn: 'InternalKafkaSG'
@@ -175,6 +192,14 @@ Resources:
       ToPort: !Ref 'ClientPort'
       GroupId: !Ref 'InternalKafkaSG'
       SourceSecurityGroupId: !Ref 'InternalSG'
+  InternalSGClientSSLIngressRule:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      IpProtocol: tcp
+      FromPort: !Ref 'ClientSSLPort'
+      ToPort: !Ref 'ClientSSLPort'
+      GroupId: !Ref 'InternalKafkaSG'
+      SourceSecurityGroupId: !Ref 'InternalSG'
   Broker1:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -193,6 +218,7 @@ Resources:
         BrokerName: !Sub '${StackName}-broker'
         DomainName: !Ref 'DomainName'
         ClientPort: !Ref 'ClientPort'
+        ClientSSLPort: !Ref 'ClientSSLPort'
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 0, !Ref 'Subnets' ]
@@ -218,6 +244,7 @@ Resources:
         BrokerName: !Sub '${StackName}-broker'
         DomainName: !Ref 'DomainName'
         ClientPort: !Ref 'ClientPort'
+        ClientSSLPort: !Ref 'ClientSSLPort'
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 1, !Ref 'Subnets' ]
@@ -243,6 +270,7 @@ Resources:
         BrokerName: !Sub '${StackName}-broker'
         DomainName: !Ref 'DomainName'
         ClientPort: !Ref 'ClientPort'
+        ClientSSLPort: !Ref 'ClientSSLPort'
         LogGroup: !Ref 'BrokersLogGroup'
         SecurityGroup: !Ref 'InternalKafkaSG'
         SubnetId: !Select [ 2, !Ref 'Subnets' ]

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -39,13 +39,13 @@ Parameters:
     Type: String
   DomainName:
     Description: The domain under which the broker will register its advertised address. (HostedZoneName)
-    Type: String 
+    Type: String
   ZookeeperConnectionString:
     Description: Connection string for Zookeeper Cluster
     Type: String
   ZookeeperSecurityGroup:
     Description: Security Group to allow access to ZK
-    Type: String  
+    Type: String
   ClientPort:
     Description: Kafka client port
     Type: Number
@@ -63,6 +63,16 @@ Parameters:
   SubnetId:
     Description: SubnetId
     Type: AWS::EC2::Subnet::Id
+  KafkaKeyPass:
+    Description: Password for the kafka keystore
+    Type: String
+    NoEcho: true
+    Default: ''
+  KafkaTrustPass:
+    Description: Password for the kafka keystore
+    Type: String
+    NoEcho: true
+    Default: ''
 
 Resources:
   BrokerNodeTaskDefinition:
@@ -92,6 +102,12 @@ Resources:
             Value: !Ref 'JMXPort'
           - Name: KAFKA_LOG4J_LOGGERS
             Value: 'kafka.controller=WARN,state.change.logger=WARN'
+          - Name: KAFKA_SSL_DIR
+            Value: '/var/private/ssl'
+          - Name: KAFKA_KEY_PASS
+            Value: !Ref 'KafkaKeyPass'
+          - Name: KAFKA_TRUST_PASS
+            Value: !Ref 'KafkaTrustPass'
         PortMappings:
           - ContainerPort: !Ref 'ClientPort'
             HostPort: !Ref 'ClientPort'
@@ -102,6 +118,8 @@ Resources:
             ContainerPath: /var/lib/kafka/data
           - SourceVolume: secrets
             ContainerPath: /etc/kafka/secrets
+          - SourceVolume: ssl
+            ContainerPath: /var/private/ssl
         LogConfiguration:
           LogDriver: awslogs
           Options:
@@ -136,6 +154,9 @@ Resources:
         - Name: secrets
           Host:
             SourcePath: !Sub '${DataVolumeMountPath}/broker/${BrokerId}/secrets'
+        - Name: ssl
+          Host:
+            SourcePath: !Sub '${DataVolumeMountPath}/ssl'
       Family: !Sub '${StackName}-broker-${BrokerId}'
   BrokerNodeService:
     Type: 'AWS::ECS::Service'
@@ -155,7 +176,7 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 100
         MinimumHealthyPercent: 0
-        
+
 Outputs:
   ConnectionString:
     Description: The connection string for this broker

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -131,7 +131,7 @@ Resources:
           - Name: KAFKA_SECURITY_INTER_BROKER_PROTOCOL
             Value: 'SSL'
           - Name: KAFKA_SSL_CLIENT_AUTH
-            Value: 'none'
+            Value: 'required'
           - Name: DUMMY_VARIABLE
             Value: 'blah'
           - Name: KAFKA_LOG4J_LOGGERS

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -50,6 +50,10 @@ Parameters:
     Description: Kafka client port
     Type: Number
     Default: 9092
+  ClientSSLPort:
+    Description: Kafka client SSL port
+    Type: Number
+    Default: 9093
   JMXPort:
     Description: JMX Port to expose metrics on
     Type: Number
@@ -81,7 +85,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
       - Name: broker
-        Image: loyaltyone/cp-kafka:0.1-beta
+        Image: loyaltyone/cp-kafka:0.11-beta
         Cpu: !Ref 'ServiceCpu'
         MemoryReservation: !Ref 'ServiceMemory'
         User: root
@@ -93,7 +97,7 @@ Resources:
           - Name: KAFKA_ZOOKEEPER_CONNECT
             Value: !Ref 'ZookeeperConnectionString'
           - Name: KAFKA_ADVERTISED_LISTENERS
-            Value: !Sub 'PLAINTEXT://${BrokerName}${BrokerId}.${DomainName}:${ClientPort}'
+            Value: !Sub 'SSL://${BrokerName}${BrokerId}.${DomainName}:${ClientSSLPort},PLAINTEXT://${BrokerName}${BrokerId}.${DomainName}:${ClientPort}'
           - Name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
             Value: 2
           - Name: KAFKA_JMX_HOSTNAME
@@ -104,13 +108,43 @@ Resources:
             Value: 'kafka.controller=WARN,state.change.logger=WARN'
           - Name: KAFKA_SSL_DIR
             Value: '/var/private/ssl'
-          - Name: KAFKA_KEY_PASS
+          - Name: KAFKA_SSL_KEYSTORE_LOCATION
+            Value: '/var/private/ssl/kafka.keystore.jks'
+          - Name: KAFKA_SSL_KEYSTORE_FILENAME
+            Value: 'kafka.keystore.jks'
+          - Name: KAFKA_SSL_KEYSTORE_PASSWORD
             Value: !Ref 'KafkaKeyPass'
-          - Name: KAFKA_TRUST_PASS
+          - Name: KAFKA_SSL_KEY_PASSWORD
+            Value: !Ref 'KafkaKeyPass'
+          - Name: KAFKA_SSL_KEY_CREDENTIALS
+            Value: 'broker_sslkey_creds'
+          - Name: KAFKA_SSL_KEYSTORE_CREDENTIALS
+            Value: 'broker_keystore_creds'
+          - Name: KAFKA_SSL_TRUSTSTORE_CREDENTIALS
+            Value: 'broker_truststore_creds'
+          - Name: KAFKA_SSL_TRUSTSTORE_LOCATION
+            Value: '/var/private/ssl/kafka.truststore.jks'
+          - Name: KAFKA_SSL_TRUSTSTORE_FILENAME
+            Value: 'kafka.truststore.jks'
+          - Name: KAFKA_SSL_TRUSTSTORE_PASSWORD
             Value: !Ref 'KafkaTrustPass'
+          - Name: KAFKA_SECURITY_INTER_BROKER_PROTOCOL
+            Value: 'SSL'
+          - Name: KAFKA_SSL_CLIENT_AUTH
+            Value: 'none'
+          - Name: DUMMY_VARIABLE
+            Value: 'blah'
+          - Name: KAFKA_LOG4J_LOGGERS
+            Value: 'kafka.network.RequestChannel=DEBUG'
+          - Name: KAFKA_LOG4J_ROOT_LOGLEVEL
+            Value: 'DEBUG'
+          - Name: KAFKA_TOOLS_LOG4J_LOGLEVEL
+            Value: 'DEBUG'
         PortMappings:
           - ContainerPort: !Ref 'ClientPort'
             HostPort: !Ref 'ClientPort'
+          - ContainerPort: !Ref 'ClientSSLPort'
+            HostPort: !Ref 'ClientSSLPort'
           - ContainerPort: !Ref 'JMXPort'
             HostPort: !Ref 'JMXPort'
         MountPoints:
@@ -181,3 +215,6 @@ Outputs:
   ConnectionString:
     Description: The connection string for this broker
     Value: !Sub '${BrokerName}${BrokerId}.${DomainName}:${ClientPort}'
+  SSLConnectionString:
+    Description: The connection string for this broker
+    Value: !Sub '${BrokerName}${BrokerId}.${DomainName}:${ClientSSLPort}'

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -136,15 +136,17 @@ Resources:
             Value: 'required'
           - Name: KAFKA_SSL_SECURE_RANDOM_IMPLEMENTATION
             Value: 'SHA1PRNG'
-          #- Name: KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
-          #  Value: 'HTTPS'
-          #- Name: KAFKA_LOG4J_LOGGERS
-          #  Value: 'kafka.network.RequestChannel=DEBUG'
-          #- Name: KAFKA_LOG4J_ROOT_LOGLEVEL
-          #  Value: 'DEBUG'
-          #- Name: KAFKA_TOOLS_LOG4J_LOGLEVEL
-          #  Value: 'DEBUG'
+          - Name: KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
+            Value: 'HTTPS'
+#          - Name: KAFKA_LOG4J_LOGGERS
+#            Value: 'kafka.network.RequestChannel=DEBUG'
+#          - Name: KAFKA_LOG4J_ROOT_LOGLEVEL
+#            Value: 'DEBUG'
+#          - Name: KAFKA_TOOLS_LOG4J_LOGLEVEL
+#            Value: 'DEBUG'
         PortMappings:
+          - ContainerPort: !Ref 'ClientPort'
+            HostPort: !Ref 'ClientPort'
           - ContainerPort: !Ref 'ClientSSLPort'
             HostPort: !Ref 'ClientSSLPort'
           - ContainerPort: !Ref 'JMXPort'

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -38,7 +38,9 @@ Parameters:
     Description: The name of the broker. Used to register a dns entry in route53
     Type: String
   DomainName:
-    Description: The domain under which the broker will register its advertised address. (HostedZoneName)
+    Description: >
+      The domain under which the broker will register its advertised address.
+      Note: This is the HostedZoneName without the period suffix.
     Type: String
   ZookeeperConnectionString:
     Description: Connection string for Zookeeper Cluster
@@ -97,7 +99,7 @@ Resources:
           - Name: KAFKA_ZOOKEEPER_CONNECT
             Value: !Ref 'ZookeeperConnectionString'
           - Name: KAFKA_ADVERTISED_LISTENERS
-            Value: !Sub 'SSL://${BrokerName}${BrokerId}.internal.loyalty.com:${ClientSSLPort}'
+            Value: !Sub 'SSL://${BrokerName}${BrokerId}.${DomainName}:${ClientSSLPort},PLAINTEXT://${BrokerName}${BrokerId}.${DomainName}:${ClientPort}'
           - Name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
             Value: 2
           - Name: KAFKA_JMX_HOSTNAME
@@ -132,9 +134,17 @@ Resources:
             Value: 'SSL'
           - Name: KAFKA_SSL_CLIENT_AUTH
             Value: 'required'
+          - Name: KAFKA_SSL_SECURE_RANDOM_IMPLEMENTATION
+            Value: 'SHA1PRNG'
+          #- Name: KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
+          #  Value: 'HTTPS'
+          #- Name: KAFKA_LOG4J_LOGGERS
+          #  Value: 'kafka.network.RequestChannel=DEBUG'
+          #- Name: KAFKA_LOG4J_ROOT_LOGLEVEL
+          #  Value: 'DEBUG'
+          #- Name: KAFKA_TOOLS_LOG4J_LOGLEVEL
+          #  Value: 'DEBUG'
         PortMappings:
-          - ContainerPort: !Ref 'ClientPort'
-            HostPort: !Ref 'ClientPort'
           - ContainerPort: !Ref 'ClientSSLPort'
             HostPort: !Ref 'ClientSSLPort'
           - ContainerPort: !Ref 'JMXPort'
@@ -208,5 +218,5 @@ Outputs:
     Description: The connection string for this broker
     Value: !Sub '${BrokerName}${BrokerId}.${DomainName}:${ClientPort}'
   SSLConnectionString:
-    Description: The connection string for this broker
+    Description: The SSL connection string for this broker
     Value: !Sub '${BrokerName}${BrokerId}.${DomainName}:${ClientSSLPort}'

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -138,12 +138,12 @@ Resources:
             Value: 'SHA1PRNG'
           - Name: KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
             Value: 'HTTPS'
-#          - Name: KAFKA_LOG4J_LOGGERS
-#            Value: 'kafka.network.RequestChannel=DEBUG'
-#          - Name: KAFKA_LOG4J_ROOT_LOGLEVEL
-#            Value: 'DEBUG'
-#          - Name: KAFKA_TOOLS_LOG4J_LOGLEVEL
-#            Value: 'DEBUG'
+          - Name: KAFKA_LOG4J_LOGGERS
+            Value: 'kafka.network.RequestChannel=WARN'
+          - Name: KAFKA_LOG4J_ROOT_LOGLEVEL
+            Value: 'INFO, stdout'
+          - Name: KAFKA_TOOLS_LOG4J_LOGLEVEL
+            Value: 'WARN, stderr'
         PortMappings:
           - ContainerPort: !Ref 'ClientPort'
             HostPort: !Ref 'ClientPort'

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -97,7 +97,7 @@ Resources:
           - Name: KAFKA_ZOOKEEPER_CONNECT
             Value: !Ref 'ZookeeperConnectionString'
           - Name: KAFKA_ADVERTISED_LISTENERS
-            Value: !Sub 'SSL://${BrokerName}${BrokerId}.${DomainName}:${ClientSSLPort},PLAINTEXT://${BrokerName}${BrokerId}.${DomainName}:${ClientPort}'
+            Value: !Sub 'SSL://${BrokerName}${BrokerId}.internal.loyalty.com:${ClientSSLPort}'
           - Name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
             Value: 2
           - Name: KAFKA_JMX_HOSTNAME
@@ -132,14 +132,6 @@ Resources:
             Value: 'SSL'
           - Name: KAFKA_SSL_CLIENT_AUTH
             Value: 'required'
-          - Name: DUMMY_VARIABLE
-            Value: 'blah'
-          - Name: KAFKA_LOG4J_LOGGERS
-            Value: 'kafka.network.RequestChannel=DEBUG'
-          - Name: KAFKA_LOG4J_ROOT_LOGLEVEL
-            Value: 'DEBUG'
-          - Name: KAFKA_TOOLS_LOG4J_LOGLEVEL
-            Value: 'DEBUG'
         PortMappings:
           - ContainerPort: !Ref 'ClientPort'
             HostPort: !Ref 'ClientPort'

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -167,12 +167,12 @@ Parameters:
     Type: String
     Description: the ARN of the Private CA that signs the broker certificate
   KafkaKeyPass:
-    Description: Password for the kafka keystore
+    Description: Password for the Kafka keystore
     Type: String
     NoEcho: true
     Default: ''
   KafkaTrustPass:
-    Description: Password for the kafka keystore
+    Description: Password for the Kafka truststore
     Type: String
     NoEcho: true
     Default: ''
@@ -195,7 +195,7 @@ Resources:
         Environment: !Ref 'Environment'
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
-        DomainName: '${DomainName}'
+        DomainName: !Ref 'DomainName'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
@@ -263,7 +263,7 @@ Resources:
         Environment: !Ref 'Environment'
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
-        DomainName: '${DomainName}'
+        DomainName: !Ref 'DomainName'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -192,9 +192,6 @@ Parameters:
   CertificateOrganizationUnit:
     Description: The organization unit to use in the certificate
     Type: String
-  IssuingCaS3Path:
-    Description: The S3 path for the Issuing CA's certificate
-    Type: String
 
 Resources:
   # Create a 3-node ECS cluster for Kafka brokers
@@ -220,7 +217,6 @@ Resources:
         CertificateLocalityName: !Ref 'CertificateLocalityName'
         CertificateOrganizationName: !Ref 'CertificateOrganizationName'
         CertificateOrganizationUnit: !Ref 'CertificateOrganizationUnit'
-        IssuingCaS3Path: !Ref 'IssuingCaS3Path'
         KafkaKeyPass: !Ref 'KafkaKeyPass'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
@@ -295,7 +291,6 @@ Resources:
         CertificateLocalityName: !Ref 'CertificateLocalityName'
         CertificateOrganizationName: !Ref 'CertificateOrganizationName'
         CertificateOrganizationUnit: !Ref 'CertificateOrganizationUnit'
-        IssuingCaS3Path: !Ref 'IssuingCaS3Path'
         KafkaKeyPass: ''
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -157,6 +157,20 @@ Parameters:
     Type: String
     Description: Name of the CF stack used to create the Kinesis stream
 
+  PrivateCaArn:
+    Type: String
+    Description: the ARN of the Private CA that signs the broker certificate
+  KafkaKeyPass:
+    Description: Password for the kafka keystore
+    Type: String
+    NoEcho: true
+    Default: ''
+  KafkaTrustPass:
+    Description: Password for the kafka keystore
+    Type: String
+    NoEcho: true
+    Default: ''
+
 Resources:
   # Create a 3-node ECS cluster for Kafka brokers
   ECSBrokers:
@@ -181,6 +195,7 @@ Resources:
         ParentStackName: !Ref 'AWS::StackName'
         VolumeNameTag: 'broker-data'
         KinesisStackName: !Ref 'KinesisStackName'
+        PrivateCaArn: !Ref 'PrivateCaArn'
     DependsOn: ['EBSBrokerVolume1','EBSBrokerVolume2','EBSBrokerVolume3']
   EBSBrokerVolume1:
     Type: 'AWS::CloudFormation::Stack'
@@ -245,6 +260,7 @@ Resources:
         ParentStackName: !Ref 'AWS::StackName'
         VolumeNameTag: 'zk-data'
         KinesisStackName: !Ref 'KinesisStackName'
+        PrivateCaArn: !Ref 'PrivateCaArn'
     DependsOn: ['EBSZKVolume1','EBSZKVolume2','EBSZKVolume3']
   EBSZKVolume1:
     Type: 'AWS::CloudFormation::Stack'
@@ -361,6 +377,8 @@ Resources:
         DataVolumeMountPath: !GetAtt 'ECSBrokers.Outputs.EBSMountPath'
         InternalSG: !GetAtt 'InternalSecurityGroup.GroupId'
         KinesisStackName: !Ref 'KinesisStackName'
+        KafkaKeyPass: !Ref 'KafkaKeyPass'
+        KafkaTrustPass: !Ref 'KafkaTrustPass'
     DependsOn: ['ECSBrokers', 'Zookeeper']
 
   # Security group to allow internal communications for this stack.

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -163,6 +163,7 @@ Parameters:
     Type: String
     Description: Name of the CF stack used to create the Kinesis stream
 
+  # Certificate information
   PrivateCaArn:
     Type: String
     Description: the ARN of the Private CA that signs the broker certificate
@@ -176,6 +177,24 @@ Parameters:
     Type: String
     NoEcho: true
     Default: ''
+  CertificateCountry:
+    Description: The country to use in the certificate (usually 2 character country code like CA)
+    Type: String
+  CertificateState:
+    Description: The state or province to use in the certificate
+    Type: String
+  CertificateLocalityName:
+    Description: The locality name to use in the certificate
+    Type: String
+  CertificateOrganizationName:
+    Description: The organization name to use in the certificate
+    Type: String
+  CertificateOrganizationUnit:
+    Description: The organization unit to use in the certificate
+    Type: String
+  IssuingCaS3Path:
+    Description: The S3 path for the Issuing CA's certificate
+    Type: String
 
 Resources:
   # Create a 3-node ECS cluster for Kafka brokers
@@ -196,6 +215,13 @@ Resources:
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
         DomainName: !Ref 'DomainName'
+        CertificateCountry: !Ref 'CertificateCountry'
+        CertificateState: !Ref 'CertificateState'
+        CertificateLocalityName: !Ref 'CertificateLocalityName'
+        CertificateOrganizationName: !Ref 'CertificateOrganizationName'
+        CertificateOrganizationUnit: !Ref 'CertificateOrganizationUnit'
+        IssuingCaS3Path: !Ref 'IssuingCaS3Path'
+        KafkaKeyPass: !Ref 'KafkaKeyPass'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
@@ -264,6 +290,13 @@ Resources:
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
         DomainName: !Ref 'DomainName'
+        CertificateCountry: !Ref 'CertificateCountry'
+        CertificateState: !Ref 'CertificateState'
+        CertificateLocalityName: !Ref 'CertificateLocalityName'
+        CertificateOrganizationName: !Ref 'CertificateOrganizationName'
+        CertificateOrganizationUnit: !Ref 'CertificateOrganizationUnit'
+        IssuingCaS3Path: !Ref 'IssuingCaS3Path'
+        KafkaKeyPass: ''
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'

--- a/master-template.yaml
+++ b/master-template.yaml
@@ -37,6 +37,12 @@ Parameters:
   BastionSG:
     Description: Security group used to whitelist for SSH access
     Type: AWS::EC2::SecurityGroup::Id
+  DomainName:
+    Description: >
+      The domain under which the Kafka and Zookeeper nodes will register their advertised address.
+      Note: This is the HostedZoneName without the period suffix.
+    Type: String
+
   BrokerInstanceType:
     Description: Which instance type should we use to build the Kafka ECS cluster
     Type: String
@@ -189,6 +195,7 @@ Resources:
         Environment: !Ref 'Environment'
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
+        DomainName: '${DomainName}'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
@@ -196,6 +203,8 @@ Resources:
         VolumeNameTag: 'broker-data'
         KinesisStackName: !Ref 'KinesisStackName'
         PrivateCaArn: !Ref 'PrivateCaArn'
+        SetupBrokerCerts: 'yes'
+        NodeCount: 3
     DependsOn: ['EBSBrokerVolume1','EBSBrokerVolume2','EBSBrokerVolume3']
   EBSBrokerVolume1:
     Type: 'AWS::CloudFormation::Stack'
@@ -254,6 +263,7 @@ Resources:
         Environment: !Ref 'Environment'
         HostedZoneId: !ImportValue
           'Fn::Sub': '${HostedZoneStackName}-ZoneId'
+        DomainName: '${DomainName}'
         RollingDeploymentVersion: !Ref 'RollingDeploymentVersion'
         AdditionalSecurityGroup: !GetAtt 'InternalSecurityGroup.GroupId'
         BastionSG: !Ref 'BastionSG'
@@ -261,6 +271,8 @@ Resources:
         VolumeNameTag: 'zk-data'
         KinesisStackName: !Ref 'KinesisStackName'
         PrivateCaArn: !Ref 'PrivateCaArn'
+        SetupBrokerCerts: 'no'
+        NodeCount: 3
     DependsOn: ['EBSZKVolume1','EBSZKVolume2','EBSZKVolume3']
   EBSZKVolume1:
     Type: 'AWS::CloudFormation::Stack'
@@ -350,8 +362,7 @@ Resources:
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
-        DomainName: !ImportValue
-          'Fn::Sub': '${HostedZoneStackName}-ZoneName'
+        DomainName: !Ref 'DomainName'
         DataVolumeMountPath: !GetAtt 'ECSZK.Outputs.EBSMountPath'
         InternalSG: !GetAtt 'InternalSecurityGroup.GroupId'
         KinesisStackName: !Ref 'KinesisStackName'
@@ -372,8 +383,7 @@ Resources:
         Project: !Ref 'Project'
         Team: !Ref 'Team'
         Environment: !Ref 'Environment'
-        DomainName: !ImportValue
-          'Fn::Sub': '${HostedZoneStackName}-ZoneName'
+        DomainName: !Ref 'DomainName'
         DataVolumeMountPath: !GetAtt 'ECSBrokers.Outputs.EBSMountPath'
         InternalSG: !GetAtt 'InternalSecurityGroup.GroupId'
         KinesisStackName: !Ref 'KinesisStackName'
@@ -412,6 +422,11 @@ Outputs:
     Value: !GetAtt 'Brokers.Outputs.ConnectionString'
     Export:
       Name: !Sub '${AWS::StackName}-KafkaConnectionString'
+  KafkaSSLConnectionString:
+    Description: 'Comma delimited list of Kafka broker addresses'
+    Value: !GetAtt 'Brokers.Outputs.SSLConnectionString'
+    Export:
+      Name: !Sub '${AWS::StackName}-KafkaSSLConnectionString'
   SchemaRegistryURL:
     Description: 'The URL for Kafka Schema Registry'
     Value: !GetAtt 'Services.Outputs.SchemaRegistryURL'

--- a/zookeeper/cluster.yaml
+++ b/zookeeper/cluster.yaml
@@ -69,7 +69,9 @@ Parameters:
     Default: dev
     ConstraintDescription: Must be one of dev|sandbox|prod.
   DomainName:
-    Description: The domain name for Zookeeper hosts
+    Description: >
+      The domain under which the zookeeper node will register its advertised address.
+      Note: This is the HostedZoneName without the period suffix.
     Type: String
   KinesisStackName:
     Type: String

--- a/zookeeper/service.yaml
+++ b/zookeeper/service.yaml
@@ -70,7 +70,9 @@ Parameters:
     Type: Number
     Default: 9404
   DomainName:
-    Description: The domain name for Zookeeper hosts
+    Description: >
+      The domain under which the zookeeper node will register its advertised address.
+      Note: This is the HostedZoneName without the period suffix.
     Type: String
 Resources:
   ZkNodeTaskDefinition:


### PR DESCRIPTION
This change adds SSL support to the kafka brokers using the Amazon Private CA to issue broker SAN certificates. There is a partner PR at the kafka-infra-config repository.