### PR TITLE
Fix Schema Registry UI Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ cert-signed
 ca-cert.srl
 output/
 db/
+ssl/

--- a/schema-registry/service.yaml
+++ b/schema-registry/service.yaml
@@ -309,7 +309,7 @@ Resources:
               HostPort: 0
           Environment:
             - Name: SCHEMAREGISTRY_URL
-              Value: !Sub 'https://${DNSRecordUI}'
+              Value: !Sub 'https://${DNSRecord}'
           MemoryReservation: !Ref 'ServiceMemory'
           Essential: 'true'
           LogConfiguration:


### PR DESCRIPTION
The SCHEMAREGISTRY_URL was pointing back to the Schema Registry UI instead of Schema Registry.