### PR TITLE
Move certificate key generation logic to containers

### DIFF
--- a/build-docker-image
+++ b/build-docker-image
@@ -9,28 +9,28 @@ function usage() {
 }
 
 docker_repo=$1
-shift
 if [[ -z "${docker_repo}" ]]; then
     echo "Please specify the docker repo."
     usage
     exit 1
 fi
+shift
 
 image_name=$1
-shift
 if [[ -z "${image_name}" ]]; then
     echo "Please specify the image name."
     usage
     exit 1
 fi
+shift
 
 version=$1
-shift
 if [[ -z "${version}" ]]; then
     echo "Please specify the image version to tag with."
     usage
     exit 1
 fi
+shift
 
 pushd ${image_name}
 docker build . -t ${docker_repo}/${image_name}:${version}

--- a/build-docker-images
+++ b/build-docker-images
@@ -9,20 +9,20 @@ function usage() {
 }
 
 docker_repo=$1
-shift
 if [[ -z "${docker_repo}" ]]; then
     echo "Please specify the docker repo."
     usage
     exit 1
 fi
+shift
 
 version=$1
-shift
 if [[ -z "${version}" ]]; then
     echo "Please specify the image version to tag with."
     usage
     exit 1
 fi
+shift
 
 image_names=(jmxtrans kafka zookeeper kafka-connect kafka-rest schema-registry)
 

--- a/ecs-kafka.yaml
+++ b/ecs-kafka.yaml
@@ -659,31 +659,13 @@ Resources:
                   --validity Value=365,Type="DAYS" \
                   --idempotency-token 1234 | jq -r '.CertificateArn')
 
-                echo "Sleeping for 30 seconds while cert is issued"
+                echo "Sleeping for 30 seconds while certificate is issued..."
                 sleep 30
                 echo "cert arn:" + $certificate_arn
 
+                echo "Storing certificate for containers..."
                 aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} \
                   --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/broker.crt
-
-                echo "Decrypting KMS data key..."
-                kms_data_key_plaintext=$(aws kms decrypt --region ${AWS::Region} \
-                    --ciphertext-blob fileb://<(echo "${KmsDataKey}" | base64 -d) \
-                    --query Plaintext --output text)
-
-                echo "Decrypting broker key password..."
-                kafka_key_pass=$(openssl enc -d -aes256 \
-                    -k <(echo "${!kms_data_key_plaintext}") \
-                    -in <(echo "${KafkaKeyPass}" | base64 -d))
-
-                # Create PKCS12 format to allow importing into keystore
-                openssl pkcs12 -export \
-                  -in ${EBSMountPath}/ssl/broker.crt \
-                  -inkey ${EBSMountPath}/ssl/broker.key \
-                  -out ${EBSMountPath}/ssl/broker.p12 \
-                  -name broker -CAfile ${EBSMountPath}/ssl/ca.crt \
-                  -caname root \
-                  -password pass:${!kafka_key_pass}
           commands:
             01_setup_tags:
               command: '/usr/local/share/setup-tags'

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -636,31 +636,13 @@ Resources:
                   --validity Value=365,Type="DAYS" \
                   --idempotency-token 1234 | jq -r '.CertificateArn')
 
-                echo "Sleeping for 30 seconds while cert is issued"
+                echo "Sleeping for 30 seconds while certificate is issued..."
                 sleep 30
                 echo "cert arn:" + $certificate_arn
 
+                echo "Storing certificate for containers..."
                 aws acm-pca get-certificate --certificate-authority-arn ${PrivateCaArn} --region ${AWS::Region} \
                   --certificate-arn $certificate_arn | jq -r '.Certificate' > ${EBSMountPath}/ssl/client.crt
-
-                echo "Decrypting KMS data key..."
-                kms_data_key_plaintext=$(aws kms decrypt --region ${AWS::Region} \
-                    --ciphertext-blob fileb://<(echo "${KmsDataKey}" | base64 -d) \
-                    --query Plaintext --output text)
-
-                echo "Decrypting services key password..."
-                services_key_pass=$(openssl enc -d -aes256 \
-                    -k <(echo "${!kms_data_key_plaintext}") \
-                    -in <(echo "${ServicesKeyPass}" | base64 -d))
-
-                # Create PKCS12 format to allow importing into keystore
-                openssl pkcs12 -export \
-                  -in ${EBSMountPath}/ssl/client.crt \
-                  -inkey ${EBSMountPath}/ssl/client.key \
-                  -out ${EBSMountPath}/ssl/client.p12 \
-                  -name client -CAfile ${EBSMountPath}/ssl/ca.crt \
-                  -caname root \
-                  -password pass:${!services_key_pass}
           commands:
             01_setup_tags:
               command: '/usr/local/share/setup-tags'

--- a/kafka-connect/Dockerfile
+++ b/kafka-connect/Dockerfile
@@ -3,13 +3,15 @@ FROM confluentinc/cp-kafka-connect:4.0.0-3
 MAINTAINER LoyaltyOne
 
 RUN wget -P /usr/local/share/ https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar \
-    && pip install awscli
+    && pip install --upgrade pip \
+    && pip install awscli \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/launch \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/configure \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' \
+           -e 's/env  *[|]  *sort/env | sort | sed -e "s\/_PASSWORD=.*\/_PASSWORD=[hidden]\/g"/' etc/confluent/docker/run
 
 COPY bootstrap setup-plugins.sh s3-cp.sh /usr/local/bin/
 COPY kafka-connect-metrics.yml setup-plugins.sh s3-cp.sh /usr/local/share/
-
-#TODO: This is for local. Should remove
-COPY config/certs /root/certs
 
 RUN setup-plugins.sh
 

--- a/kafka-connect/bootstrap
+++ b/kafka-connect/bootstrap
@@ -2,6 +2,12 @@
 
 set -e
 
+function cleanup() {
+	echo "Removing PKCS key..."
+	rm -f /tmp/client.p12
+}
+trap cleanup EXIT
+
 if [ -n "$APP_PORT" ]
 then
 	echo "Configuring Kafka Connect with APP_PORT: $APP_PORT"
@@ -23,9 +29,9 @@ echo "CONNECT_REST_ADVERTISED_PORT: $CONNECT_REST_ADVERTISED_PORT"
 
 if [ -n "${KAFKA_JMX_PORT}" ] || [ -n "${KAFKA_JMX_HOSTNAME}" ] || [ -n "${KAFKA_JMX_OPTS}" ];
 then
-    # JMX agent complains about malformed URLs and is not able to resolve ECS container
-    # short hostnames. This will take care of the problem.
-    echo "127.0.0.1     $HOSTNAME" | tee -a /etc/hosts
+	# JMX agent complains about malformed URLs and is not able to resolve ECS container
+	# short hostnames. This will take care of the problem.
+	echo "127.0.0.1	 $HOSTNAME" | tee -a /etc/hosts
 fi
 echo "KAFKA_JMX_HOSTNAME: ${KAFKA_JMX_HOSTNAME}"
 echo "KAFKA_JMX_PORT: ${KAFKA_JMX_PORT}"
@@ -33,44 +39,52 @@ echo "KAFKA_JMX_PORT: ${KAFKA_JMX_PORT}"
 # If SSL directory env variable is set, generate keystore and truststore
 if [ -n "${SSL_DIR}" ];
 then
-    # If KMS data key is present, decrypt it and use that to decrypt passwords.
-    if [ -n ${KMS_DATA_KEY} ]; then
-        # NOTE: Do not export plaintext KMS data key.
-        echo "Decrypting KMS data key..."
-        kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
-            --ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
-            --query Plaintext --output text)
+	# If KMS data key is present, decrypt it and use that to decrypt passwords.
+	if [ -n ${KMS_DATA_KEY} ]; then
+		# NOTE: Do not export plaintext KMS data key.
+		echo "Decrypting KMS data key..."
+		kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
+			--ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
+			--query Plaintext --output text)
 
-        echo "Decrypting CONNECT_SSL_KEY_PASSWORD..."
-        export CONNECT_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${CONNECT_SSL_KEY_PASSWORD}" | base64 -d))
+		echo "Decrypting CONNECT_SSL_KEY_PASSWORD..."
+		export CONNECT_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${CONNECT_SSL_KEY_PASSWORD}" | base64 -d))
 
-        echo "Decrypting CONNECT_SSL_KEYSTORE_PASSWORD..."
-        export CONNECT_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${CONNECT_SSL_KEYSTORE_PASSWORD}" | base64 -d))
+		echo "Decrypting CONNECT_SSL_KEYSTORE_PASSWORD..."
+		export CONNECT_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${CONNECT_SSL_KEYSTORE_PASSWORD}" | base64 -d))
 
-        echo "Decrypting CONNECT_SSL_TRUSTSTORE_PASSWORD..."
-        export CONNECT_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${CONNECT_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
-    fi
+		echo "Decrypting CONNECT_SSL_TRUSTSTORE_PASSWORD..."
+		export CONNECT_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${CONNECT_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
+	fi
 
-	# TODO: Handle changes in passwords which would warrant generation of new truststore.
+	# Create PKCS12 format to allow importing into keystore
+	echo "Creating PKCS12 key..."
+	openssl pkcs12 -export \
+		-in ${SSL_DIR}/client.crt \
+		-inkey ${SSL_DIR}/client.key \
+		-out /tmp/client.p12 \
+		-name client -CAfile ${SSL_DIR}/ca.crt \
+		-caname root \
+		-password pass:${CONNECT_SSL_KEY_PASSWORD}
 
 	# If truststore doesn't exist, generate truststore
 	if [ ! -f ${SSL_DIR}/kafka.client.truststore.jks ];
 	then
-	  echo "Generating Truststore..."
-	  keytool -import -alias ca -file ${SSL_DIR}/ca.crt \
-	      -keystore ${SSL_DIR}/kafka.client.truststore.jks \
-	      -storepass ${CONNECT_SSL_TRUSTSTORE_PASSWORD} \
-	      -noprompt
-	  keytool -import -alias client -file ${SSL_DIR}/client.crt \
-	      -keystore ${SSL_DIR}/kafka.client.truststore.jks \
-	      -storepass ${CONNECT_SSL_TRUSTSTORE_PASSWORD} \
-	      -noprompt
+		echo "Generating Truststore..."
+		keytool -import -alias ca -file ${SSL_DIR}/ca.crt \
+			-keystore ${SSL_DIR}/kafka.client.truststore.jks \
+			-storepass ${CONNECT_SSL_TRUSTSTORE_PASSWORD} \
+			-noprompt
+		keytool -import -alias client -file ${SSL_DIR}/client.crt \
+			-keystore ${SSL_DIR}/kafka.client.truststore.jks \
+			-storepass ${CONNECT_SSL_TRUSTSTORE_PASSWORD} \
+			-noprompt
 	fi
 
 	# If keystore doesn't exist, generate keystore
@@ -81,7 +95,7 @@ then
 			-deststorepass ${CONNECT_SSL_KEYSTORE_PASSWORD} \
 			-destkeypass ${CONNECT_SSL_KEY_PASSWORD} \
 			-destkeystore ${SSL_DIR}/kafka.client.keystore.jks \
-			-srckeystore ${SSL_DIR}/client.p12 \
+			-srckeystore /tmp/client.p12 \
 			-srcstoretype PKCS12 \
 			-srcstorepass ${CONNECT_SSL_KEY_PASSWORD} \
 			-alias client

--- a/kafka-rest/Dockerfile
+++ b/kafka-rest/Dockerfile
@@ -3,7 +3,12 @@ FROM confluentinc/cp-kafka-rest:4.0.0-3
 MAINTAINER LoyaltyOne
 
 RUN wget -P /usr/local/share/ https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar \
-    && pip install awscli
+    && pip install --upgrade pip \
+    && pip install awscli \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/launch \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/configure \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' \
+           -e 's/env  *[|]  *sort/env | sort | sed -e "s\/_PASSWORD=.*\/_PASSWORD=[hidden]\/g"/' etc/confluent/docker/run
 
 COPY bootstrap /usr/local/bin/
 COPY kafka-rest-metrics.yml /usr/local/share/

--- a/kafka-rest/bootstrap
+++ b/kafka-rest/bootstrap
@@ -2,6 +2,12 @@
 
 set -e
 
+function cleanup() {
+	echo "Removing PKCS key..."
+	rm -f /tmp/client.p12
+}
+trap cleanup EXIT
+
 if [ -n "$APP_PORT" ]
 then
 	echo "Configuring REST Proxy with APP_PORT: $APP_PORT"
@@ -12,36 +18,36 @@ then
 	export HOST_IP=$(curl $DOCKER_MIRROR/hostip)
 	export HOST_PORT=$(curl $DOCKER_MIRROR/container/$HOSTNAME/port/$APP_PORT)
 
-    export KAFKA_REST_HOST_NAME=${HOST_IP}
-    export KAFKA_REST_LISTENERS="http://0.0.0.0:$HOST_PORT,http://0.0.0.0:$APP_PORT"
+	export KAFKA_REST_HOST_NAME=${HOST_IP}
+	export KAFKA_REST_LISTENERS="http://0.0.0.0:$HOST_PORT,http://0.0.0.0:$APP_PORT"
 else
-    export KAFKA_REST_HOST_NAME=${APP_HOST}
+	export KAFKA_REST_HOST_NAME=${APP_HOST}
 fi
 echo "KAFKA_REST_HOST_NAME: ${KAFKA_REST_HOST_NAME}"
 echo "KAFKA_REST_LISTENERS: ${KAFKA_REST_LISTENERS}"
 
 if [[ -z ${KAFKA_REST_ID} ]]; then
-    uuid=$(cat /proc/sys/kernel/random/uuid)
-    export KAFKA_REST_ID=${uuid}
+	uuid=$(cat /proc/sys/kernel/random/uuid)
+	export KAFKA_REST_ID=${uuid}
 fi
 echo "KAFKA_REST_ID: ${KAFKA_REST_ID}"
 
 if [ -n "${KAFKA_REST_JMX_PORT}" ] || [ -n "${KAFKA_REST_JMX_HOSTNAME}" ] || [ -n "${KAFKA_REST_JMX_OPTS}" ];
 then
-    # JMX agent complains about malformed URLs and is not able to resolve ECS container
-    # short hostnames. This will take care of the problem.
-    echo "127.0.0.1     $HOSTNAME" | tee -a /etc/hosts
+	# JMX agent complains about malformed URLs and is not able to resolve ECS container
+	# short hostnames. This will take care of the problem.
+	echo "127.0.0.1	 $HOSTNAME" | tee -a /etc/hosts
 
-    if [[ -z ${KAFKA_REST_JMX_OPTS} ]]; then
-        opts="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
-        opts="${opts} -Djava.rmi.server.hostname=${KAFKA_REST_JMX_HOSTNAME:-${HOSTNAME}} -Dcom.sun.management.jmxremote.local.only=false"
-        if [[ -n ${KAFKA_REST_JMX_PORT} ]]; then
-            opts="${opts} -Dcom.sun.management.jmxremote.rmi.port=${KAFKA_REST_JMX_PORT} -Dcom.sun.management.jmxremote.port=${KAFKA_REST_JMX_PORT}"
-        fi
-        export KAFKA_REST_JMX_OPTS=${opts}
-    fi
-    # This is the weird thing with the rest proxy and it needs KAFKAREST_JMX_OPTS
-    export KAFKAREST_JMX_OPTS=${KAFKA_REST_JMX_OPTS}
+	if [[ -z ${KAFKA_REST_JMX_OPTS} ]]; then
+		opts="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+		opts="${opts} -Djava.rmi.server.hostname=${KAFKA_REST_JMX_HOSTNAME:-${HOSTNAME}} -Dcom.sun.management.jmxremote.local.only=false"
+		if [[ -n ${KAFKA_REST_JMX_PORT} ]]; then
+			opts="${opts} -Dcom.sun.management.jmxremote.rmi.port=${KAFKA_REST_JMX_PORT} -Dcom.sun.management.jmxremote.port=${KAFKA_REST_JMX_PORT}"
+		fi
+		export KAFKA_REST_JMX_OPTS=${opts}
+	fi
+	# This is the weird thing with the rest proxy and it needs KAFKAREST_JMX_OPTS
+	export KAFKAREST_JMX_OPTS=${KAFKA_REST_JMX_OPTS}
 fi
 echo "KAFKA_REST_JMX_HOSTNAME: ${KAFKA_REST_JMX_HOSTNAME}"
 echo "KAFKA_REST_JMX_PORT: ${KAFKA_REST_JMX_PORT}"
@@ -49,31 +55,39 @@ echo "KAFKA_REST_JMX_PORT: ${KAFKA_REST_JMX_PORT}"
 # If SSL directory env variable is set, generate keystore and truststore
 if [ -n "${SSL_DIR}" ];
 then
-    # If KMS data key is present, decrypt it and use that to decrypt passwords.
-    if [ -n ${KMS_DATA_KEY} ]; then
-        # NOTE: Do not export plaintext KMS data key.
-        echo "Decrypting KMS data key..."
-        kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
-            --ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
-            --query Plaintext --output text)
+	# If KMS data key is present, decrypt it and use that to decrypt passwords.
+	if [ -n ${KMS_DATA_KEY} ]; then
+		# NOTE: Do not export plaintext KMS data key.
+		echo "Decrypting KMS data key..."
+		kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
+			--ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
+			--query Plaintext --output text)
 
-        echo "Decrypting KAFKA_REST_CLIENT_SSL_KEY_PASSWORD..."
-        export KAFKA_REST_CLIENT_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${KAFKA_REST_CLIENT_SSL_KEY_PASSWORD}" | base64 -d))
+		echo "Decrypting KAFKA_REST_CLIENT_SSL_KEY_PASSWORD..."
+		export KAFKA_REST_CLIENT_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${KAFKA_REST_CLIENT_SSL_KEY_PASSWORD}" | base64 -d))
 
-        echo "Decrypting KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD..."
-        export KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD}" | base64 -d))
+		echo "Decrypting KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD..."
+		export KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD}" | base64 -d))
 
-        echo "Decrypting KAFKA_REST_CLIENT_SSL_TRUSTSTORE_PASSWORD..."
-        export KAFKA_REST_CLIENT_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${KAFKA_REST_CLIENT_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
-    fi
+		echo "Decrypting KAFKA_REST_CLIENT_SSL_TRUSTSTORE_PASSWORD..."
+		export KAFKA_REST_CLIENT_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${KAFKA_REST_CLIENT_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
+	fi
 
-	# TODO: Handle changes in passwords which would warrant generation of new truststore.
+	# Create PKCS12 format to allow importing into keystore
+	echo "Creating PKCS12 key..."
+	openssl pkcs12 -export \
+		-in ${SSL_DIR}/client.crt \
+		-inkey ${SSL_DIR}/client.key \
+		-out /tmp/client.p12 \
+		-name client -CAfile ${SSL_DIR}/ca.crt \
+		-caname root \
+		-password pass:${KAFKA_REST_CLIENT_SSL_KEY_PASSWORD}
 
 	# If truststore doesn't exist, generate truststore
 	if [ ! -f ${SSL_DIR}/kafka.client.truststore.jks ];
@@ -97,7 +111,7 @@ then
 			-deststorepass ${KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD} \
 			-destkeypass ${KAFKA_REST_CLIENT_SSL_KEY_PASSWORD} \
 			-destkeystore ${SSL_DIR}/kafka.client.keystore.jks \
-			-srckeystore ${SSL_DIR}/client.p12 \
+			-srckeystore /tmp/client.p12 \
 			-srcstoretype PKCS12 \
 			-srcstorepass ${KAFKA_REST_CLIENT_SSL_KEY_PASSWORD} \
 			-alias client

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -2,8 +2,14 @@ FROM confluentinc/cp-kafka:4.0.0-3
 
 MAINTAINER LoyaltyOne
 
+# The sed commands turn off verbose logging so passwords get hidden
 RUN wget -P /usr/local/share/ https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar \
-    && pip install awscli
+    && pip install --upgrade pip \
+    && pip install awscli \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/launch \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/configure \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' \
+           -e 's/env  *[|]  *sort/env | sort | sed -e "s\/_PASSWORD=.*\/_PASSWORD=[hidden]\/g"/' etc/confluent/docker/run
 
 COPY bootstrap /usr/local/bin/
 COPY kafka-metrics.yml /usr/local/share/

--- a/kafka/bootstrap
+++ b/kafka/bootstrap
@@ -2,51 +2,65 @@
 
 set -e
 
+function cleanup() {
+	echo "Removing PKCS key..."
+	rm -f /tmp/broker.p12
+}
+trap cleanup EXIT
+
 if [ -n "${KAFKA_JMX_PORT}" ] || [ -n "${KAFKA_JMX_HOSTNAME}" ] || [ -n "${KAFKA_JMX_OPTS}" ];
 then
-    # JMX agent complains about malformed URLs and is not able to resolve ECS container
-    # short hostnames. This will take care of the problem.
-    echo "127.0.0.1     $HOSTNAME" | tee -a /etc/hosts
+	# JMX agent complains about malformed URLs and is not able to resolve ECS container
+	# short hostnames. This will take care of the problem.
+	echo "127.0.0.1	 $HOSTNAME" | tee -a /etc/hosts
 fi
 echo "KAFKA_JMX_HOSTNAME: ${KAFKA_JMX_HOSTNAME}"
 echo "KAFKA_JMX_PORT: ${KAFKA_JMX_PORT}"
 
 if [ -z "${KAFKA_BROKER_RACK}" ];
 then
-    # Assume AWS environment and use the AZ as the rack name. This will help with spreading replicas of the same
-    # partition across different AZs.
-    export KAFKA_BROKER_RACK=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+	# Assume AWS environment and use the AZ as the rack name. This will help with spreading replicas of the same
+	# partition across different AZs.
+	export KAFKA_BROKER_RACK=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
 fi
 echo "KAFKA_BROKER_RACK: ${KAFKA_BROKER_RACK}"
 
 # If SSL directory env variable is set we will build the keystore and truststore.
 if [ -n "${SSL_DIR}" ];
 then
-    # If KMS data key is present, decrypt it and use that to decrypt passwords.
-    if [ -n ${KMS_DATA_KEY} ]; then
-        # NOTE: Do not export plaintext KMS data key.
-        echo "Decrypting KMS data key..."
-        kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
-            --ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
-            --query Plaintext --output text)
+	# If KMS data key is present, decrypt it and use that to decrypt passwords.
+	if [ -n ${KMS_DATA_KEY} ]; then
+		# NOTE: Do not export plaintext KMS data key.
+		echo "Decrypting KMS data key..."
+		kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
+			--ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
+			--query Plaintext --output text)
 
-        echo "Decrypting KAFKA_SSL_KEY_PASSWORD..."
-        export KAFKA_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${KAFKA_SSL_KEY_PASSWORD}" | base64 -d))
+		echo "Decrypting KAFKA_SSL_KEY_PASSWORD..."
+		export KAFKA_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${KAFKA_SSL_KEY_PASSWORD}" | base64 -d))
 
-        echo "Decrypting KAFKA_SSL_KEYSTORE_PASSWORD..."
-        export KAFKA_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${KAFKA_SSL_KEYSTORE_PASSWORD}" | base64 -d))
+		echo "Decrypting KAFKA_SSL_KEYSTORE_PASSWORD..."
+		export KAFKA_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${KAFKA_SSL_KEYSTORE_PASSWORD}" | base64 -d))
 
-        echo "Decrypting KAFKA_SSL_TRUSTSTORE_PASSWORD..."
-        export KAFKA_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${KAFKA_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
-    fi
+		echo "Decrypting KAFKA_SSL_TRUSTSTORE_PASSWORD..."
+		export KAFKA_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${KAFKA_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
+	fi
 
-    # TODO: Handle changes in passwords which would warrant generation of new keystore and truststore.
+	# Create PKCS12 format to allow importing into keystore
+	echo "Creating PKCS12 key..."
+	openssl pkcs12 -export \
+		-in ${SSL_DIR}/broker.crt \
+		-inkey ${SSL_DIR}/broker.key \
+		-out /tmp/broker.p12 \
+		-name broker -CAfile ${SSL_DIR}/ca.crt \
+		-caname root \
+		-password pass:${KAFKA_SSL_KEY_PASSWORD}
 
 	# If truststore doesn't exist, generate truststore
 	if [ ! -f ${SSL_DIR}/kafka.truststore.jks ];
@@ -71,21 +85,17 @@ then
 			-deststorepass ${KAFKA_SSL_KEYSTORE_PASSWORD} \
 			-destkeypass ${KAFKA_SSL_KEY_PASSWORD} \
 			-destkeystore ${SSL_DIR}/kafka.keystore.jks \
-			-srckeystore ${SSL_DIR}/broker.p12 \
+			-srckeystore /tmp/broker.p12 \
 			-srcstoretype PKCS12 \
 			-srcstorepass ${KAFKA_SSL_KEY_PASSWORD} \
 			-alias broker
 		cp ${SSL_DIR}/kafka.keystore.jks /etc/kafka/secrets/kafka.keystore.jks
 	fi
 
-    export KAFKA_SSL_TRUSTSTORE_CREDENTIALS=${KAFKA_SSL_TRUSTSTORE_CREDENTIALS:-broker_truststore_creds}
-    export KAFKA_SSL_KEYSTORE_CREDENTIALS=${KAFKA_SSL_KEYSTORE_CREDENTIALS:-broker_keystore_creds}
-    export KAFKA_SSL_KEY_CREDENTIALS=${KAFKA_SSL_KEY_CREDENTIALS:-broker_sslkey_creds}
-
-    echo "Writing passwords to credential files..."
-    echo "KAFKA_SSL_TRUSTSTORE_CREDENTIALS: ${KAFKA_SSL_TRUSTSTORE_CREDENTIALS}"
-    echo "KAFKA_SSL_KEYSTORE_CREDENTIALS: ${KAFKA_SSL_KEYSTORE_CREDENTIALS}"
-    echo "KAFKA_SSL_KEY_CREDENTIALS: ${KAFKA_SSL_KEY_CREDENTIALS}"
+	echo "Writing passwords to credential files..."
+	echo "KAFKA_SSL_TRUSTSTORE_CREDENTIALS: ${KAFKA_SSL_TRUSTSTORE_CREDENTIALS}"
+	echo "KAFKA_SSL_KEYSTORE_CREDENTIALS: ${KAFKA_SSL_KEYSTORE_CREDENTIALS}"
+	echo "KAFKA_SSL_KEY_CREDENTIALS: ${KAFKA_SSL_KEY_CREDENTIALS}"
 
 	echo ${KAFKA_SSL_TRUSTSTORE_PASSWORD} > /etc/kafka/secrets/${KAFKA_SSL_TRUSTSTORE_CREDENTIALS}
 	echo ${KAFKA_SSL_KEYSTORE_PASSWORD} > /etc/kafka/secrets/${KAFKA_SSL_KEYSTORE_CREDENTIALS}

--- a/schema-registry/Dockerfile
+++ b/schema-registry/Dockerfile
@@ -3,7 +3,12 @@ FROM confluentinc/cp-schema-registry:4.0.0-3
 MAINTAINER LoyaltyOne
 
 RUN wget -P /usr/local/share/ https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar \
-    && pip install awscli
+    && pip install --upgrade pip \
+    && pip install awscli \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/launch \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/configure \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' \
+           -e 's/env  *[|]  *sort/env | sort | sed -e "s\/_PASSWORD=.*\/_PASSWORD=[hidden]\/g"/' etc/confluent/docker/run
 
 COPY bootstrap /usr/local/bin/
 COPY schema-registry-metrics.yml /usr/local/share/

--- a/schema-registry/bootstrap
+++ b/schema-registry/bootstrap
@@ -2,9 +2,15 @@
 
 set -e
 
+function cleanup() {
+	echo "Removing PKCS key..."
+	rm -f /tmp/client.p12
+}
+trap cleanup EXIT
+
 if [ -n "$APP_PORT" ]
 then
-    echo "Configuring Schema Registry with APP_PORT: $APP_PORT"
+	echo "Configuring Schema Registry with APP_PORT: $APP_PORT"
 	DOCKER_MIRROR_HOST=$(/sbin/ip route|awk '/default/ { print $3 }')
 	DOCKER_MIRROR_PORT=${MIRROR_PORT:-9001}
 	DOCKER_MIRROR="http://$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT"
@@ -22,9 +28,9 @@ echo "SCHEMA_REGISTRY_LISTENERS: $SCHEMA_REGISTRY_LISTENERS"
 
 if [ -n "${SCHEMA_REGISTRY_JMX_PORT}" ] || [ -n "${SCHEMA_REGISTRY_JMX_HOSTNAME}" ] || [ -n "${SCHEMA_REGISTRY_JMX_OPTS}" ];
 then
-    # JMX agent complains about malformed URLs and is not able to resolve ECS container
-    # short hostnames. This will take care of the problem.
-    echo "127.0.0.1     $HOSTNAME" | tee -a /etc/hosts
+	# JMX agent complains about malformed URLs and is not able to resolve ECS container
+	# short hostnames. This will take care of the problem.
+	echo "127.0.0.1	 $HOSTNAME" | tee -a /etc/hosts
 fi
 echo "SCHEMA_REGISTRY_JMX_HOSTNAME: ${SCHEMA_REGISTRY_JMX_HOSTNAME}"
 echo "SCHEMA_REGISTRY_JMX_PORT: ${SCHEMA_REGISTRY_JMX_PORT}"
@@ -32,31 +38,39 @@ echo "SCHEMA_REGISTRY_JMX_PORT: ${SCHEMA_REGISTRY_JMX_PORT}"
 # If SSL directory env variable is set, generate keystore and truststore
 if [ -n "${SSL_DIR}" ];
 then
-    # If KMS data key is present, decrypt it and use that to decrypt passwords.
-    if [ -n ${KMS_DATA_KEY} ]; then
-        # NOTE: Do not export plaintext KMS data key.
-        echo "Decrypting KMS data key..."
-        kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
-            --ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
-            --query Plaintext --output text)
+	# If KMS data key is present, decrypt it and use that to decrypt passwords.
+	if [ -n ${KMS_DATA_KEY} ]; then
+		# NOTE: Do not export plaintext KMS data key.
+		echo "Decrypting KMS data key..."
+		kms_data_key_plaintext=$(aws kms decrypt --region ${REGION} \
+			--ciphertext-blob fileb://<(echo ${KMS_DATA_KEY} | base64 -d) \
+			--query Plaintext --output text)
 
-        echo "Decrypting SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD..."
-        export SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD}" | base64 -d))
+		echo "Decrypting SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD..."
+		export SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD}" | base64 -d))
 
-        echo "Decrypting SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD..."
-        export SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD}" | base64 -d))
+		echo "Decrypting SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD..."
+		export SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD}" | base64 -d))
 
-        echo "Decrypting SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD..."
-        export SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
-            -k <(echo "${kms_data_key_plaintext}") \
-            -in <(echo "${SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
-    fi
+		echo "Decrypting SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD..."
+		export SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD=$(openssl enc -d -aes256 \
+			-k <(echo "${kms_data_key_plaintext}") \
+			-in <(echo "${SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD}" | base64 -d))
+	fi
 
-	# TODO: Handle changes in passwords which would warrant generation of new truststore.
+	# Create PKCS12 format to allow importing into keystore
+	echo "Creating PKCS12 key..."
+	openssl pkcs12 -export \
+		-in ${SSL_DIR}/client.crt \
+		-inkey ${SSL_DIR}/client.key \
+		-out /tmp/client.p12 \
+		-name client -CAfile ${SSL_DIR}/ca.crt \
+		-caname root \
+		-password pass:${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD}
 
 	# If truststore doesn't exist, generate truststore
 	if [ ! -f ${SSL_DIR}/kafka.client.truststore.jks ];
@@ -80,7 +94,7 @@ then
 			-deststorepass ${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD} \
 			-destkeypass ${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD} \
 			-destkeystore ${SSL_DIR}/kafka.client.keystore.jks \
-			-srckeystore ${SSL_DIR}/client.p12 \
+			-srckeystore /tmp/client.p12 \
 			-srcstoretype PKCS12 \
 			-srcstorepass ${SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD} \
 			-alias client

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -2,7 +2,11 @@ FROM confluentinc/cp-zookeeper:4.0.0-3
 
 MAINTAINER LoyaltyOne
 
-RUN wget -P /usr/local/share/ https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar
+RUN wget -P /usr/local/share/ https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/launch \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' /etc/confluent/docker/configure \
+    && sed -i -e 's/-o errexit.*/-o errexit/g' -e 's/-o verbose.*//g' -e 's/-o xtrace.*//g' \
+           -e 's/env  *[|]  *sort/env | sort | sed -e "s\/_PASSWORD=.*\/_PASSWORD=[hidden]\/g"/' etc/confluent/docker/run
 
 COPY bootstrap /usr/local/bin/
 COPY zookeeper-metrics.yml /usr/local/share/


### PR DESCRIPTION
* Moved keys and certificate generation to docker containers to avoid issues with having it done in multiple places.
* Disabled verbose and trace logging in bash scripts to avoid dumping sensitive passwords in the logs