### PR TITLE
Allow overriding Node Id from a file

### DIFF
--- a/kafka-connect/service.yaml
+++ b/kafka-connect/service.yaml
@@ -190,7 +190,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Name: !Ref 'AppName'
-          Image: loyaltyone/kafka-connect:0.1.0
+          Image: loyaltyone/kafka-connect:0.2.0
           Cpu: !Ref 'ServiceCpu'
           PortMappings:
             - ContainerPort: !Ref 'AppContainerPort'
@@ -266,7 +266,7 @@ Resources:
             - SourceVolume: ssl
               ContainerPath: /var/private/ssl
         - Name: jmxtrans
-          Image: loyaltyone/jmxtrans:0.1.0
+          Image: loyaltyone/jmxtrans:0.2.0
           Cpu: !Ref 'JmxtransCpu'
           MemoryReservation: !Ref 'JmxtransMemory'
           Links: [!Ref 'AppName']

--- a/kafka-rest/service.yaml
+++ b/kafka-rest/service.yaml
@@ -187,7 +187,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Name: !Ref 'AppName'
-          Image: loyaltyone/kafka-rest:0.1.0
+          Image: loyaltyone/kafka-rest:0.2.0
           Cpu: !Ref 'ServiceCpu'
           PortMappings:
             - ContainerPort: !Ref 'AppContainerPort'
@@ -239,7 +239,7 @@ Resources:
             - SourceVolume: ssl
               ContainerPath: /var/private/ssl
         - Name: jmxtrans
-          Image: loyaltyone/jmxtrans:0.1.0
+          Image: loyaltyone/jmxtrans:0.2.0
           Cpu: !Ref 'JmxtransCpu'
           MemoryReservation: !Ref 'JmxtransMemory'
           Links: [!Ref 'AppName']

--- a/kafka/bootstrap
+++ b/kafka/bootstrap
@@ -8,6 +8,14 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+# The id in NODE_ID_FILE_PATH will override KAFKA_BROKER_ID
+if [ -n "${NODE_ID_FILE_PATH}" ] && [ -f "${NODE_ID_FILE_PATH}" ];
+then
+    echo "Overriding KAFKA_BROKER_ID from '${NODE_ID_FILE_PATH}'..."
+    KAFKA_BROKER_ID=$(cat ${NODE_ID_FILE_PATH})
+fi
+echo "KAFKA_BROKER_ID: ${KAFKA_BROKER_ID}"
+
 if [ -n "${KAFKA_JMX_PORT}" ] || [ -n "${KAFKA_JMX_HOSTNAME}" ] || [ -n "${KAFKA_JMX_OPTS}" ];
 then
 	# JMX agent complains about malformed URLs and is not able to resolve ECS container

--- a/kafka/cluster.yaml
+++ b/kafka/cluster.yaml
@@ -292,7 +292,7 @@ Resources:
         KeyPass: !Ref 'KeyPass'
         KeystorePass: !Ref 'KeystorePass'
         TruststorePass: !Ref 'TruststorePass'
-    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
+    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG', 'Broker1']
   Broker3:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -322,7 +322,7 @@ Resources:
         KeyPass: !Ref 'KeyPass'
         KeystorePass: !Ref 'KeystorePass'
         TruststorePass: !Ref 'TruststorePass'
-    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG']
+    DependsOn: ['BrokersLogGroup', 'InternalKafkaSG', 'Broker2']
 
 Outputs:
   ClientKafkaSG:

--- a/kafka/service.yaml
+++ b/kafka/service.yaml
@@ -117,7 +117,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: broker
-          Image: loyaltyone/kafka:0.1.0
+          Image: loyaltyone/kafka:0.2.0
           Cpu: !Ref 'ServiceCpu'
           MemoryReservation: !Ref 'ServiceMemory'
           User: root
@@ -205,7 +205,7 @@ Resources:
               awslogs-region: !Ref 'AWS::Region'
               awslogs-stream-prefix: !Sub 'broker${BrokerId}'
         - Name: jmxtrans
-          Image: loyaltyone/jmxtrans:0.1.0
+          Image: loyaltyone/jmxtrans:0.2.0
           Cpu: !Ref 'JmxtransCpu'
           MemoryReservation: !Ref 'JmxtransMemory'
           Environment:

--- a/schema-registry/service.yaml
+++ b/schema-registry/service.yaml
@@ -217,7 +217,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Name: !Ref 'AppName'
-          Image: loyaltyone/schema-registry:0.1.0
+          Image: loyaltyone/schema-registry:0.2.0
           Cpu: !Ref 'ServiceCpu'
           PortMappings:
             - ContainerPort: !Ref 'AppContainerPort'
@@ -273,7 +273,7 @@ Resources:
             - SourceVolume: ssl
               ContainerPath: /var/private/ssl
         - Name: jmxtrans
-          Image: loyaltyone/jmxtrans:0.1.0
+          Image: loyaltyone/jmxtrans:0.2.0
           Cpu: !Ref 'JmxtransCpu'
           MemoryReservation: !Ref 'JmxtransMemory'
           Links: [!Ref 'AppName']

--- a/zookeeper/bootstrap
+++ b/zookeeper/bootstrap
@@ -2,6 +2,14 @@
 
 set -e
 
+# The id in NODE_ID_FILE_PATH will override ZOOKEEPER_SERVER_ID
+if [ -n "${NODE_ID_FILE_PATH}" ] && [ -f "${NODE_ID_FILE_PATH}" ];
+then
+    echo "Overriding ZOOKEEPER_SERVER_ID from '${NODE_ID_FILE_PATH}'..."
+    ZOOKEEPER_SERVER_ID=$(cat ${NODE_ID_FILE_PATH})
+fi
+echo "ZOOKEEPER_SERVER_ID: ${ZOOKEEPER_SERVER_ID}"
+
 if [ -n "${KAFKA_JMX_PORT}" ] || [ -n "${KAFKA_JMX_HOSTNAME}" ] || [ -n "${KAFKA_JMX_OPTS}" ];
 then
     # JMX agent complains about malformed URLs and is not able to resolve ECS container

--- a/zookeeper/cluster.yaml
+++ b/zookeeper/cluster.yaml
@@ -226,7 +226,7 @@ Resources:
         SubnetId: !Select [ 1, !Ref 'Subnets' ]
         DomainName: !Ref 'DomainName'
         JMXPort: 8991
-    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG']
+    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG', 'ZKNode1']
   ZKNode3:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -250,7 +250,7 @@ Resources:
         SubnetId: !Select [ 2, !Ref 'Subnets' ]
         DomainName: !Ref 'DomainName'
         JMXPort: 8992
-    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG']
+    DependsOn: ['ZKNodesLogGroup', 'InternalZKSG', 'ZKNode2']
 
 Outputs:
   ClientZKSG:

--- a/zookeeper/service.yaml
+++ b/zookeeper/service.yaml
@@ -81,7 +81,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
       - Name: zookeeper
-        Image: loyaltyone/zookeeper:0.1.0
+        Image: loyaltyone/zookeeper:0.2.0
         Cpu: !Ref 'ServiceCpu'
         MemoryReservation: !Ref 'ServiceMemory'
         User: root
@@ -127,7 +127,7 @@ Resources:
             awslogs-region: !Ref 'AWS::Region'
             awslogs-stream-prefix: !Sub 'zk${ServerId}'
       - Name: jmxtrans
-        Image: loyaltyone/jmxtrans:0.1.0
+        Image: loyaltyone/jmxtrans:0.2.0
         Cpu: !Ref 'JmxtransCpu'
         MemoryReservation: !Ref 'JmxtransMemory'
         Environment:


### PR DESCRIPTION
#### Description

This will help transition from pre-configured IDs to ones setup with the corresponding EBS data volumes.

Also added dependencies between nodes so that a rolling deployment occurs and not all nodes go down simultaneously (this can still happen while leader elections occur)