### PR TITLE
Add one-minute-rate metric for topic throughput

### DIFF
--- a/jmxtrans/config/kafka-aws.json
+++ b/jmxtrans/config/kafka-aws.json
@@ -9,7 +9,7 @@
         {
           "obj": "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec",
           "resultAlias": "kafka-server",
-          "attr": ["Count"],
+          "attr": ["Count", "OneMinuteRate"],
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.CloudWatchWriter",
@@ -27,7 +27,7 @@
         {
           "obj": "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec",
           "resultAlias": "kafka-server",
-          "attr": ["Count"],
+          "attr": ["Count", "OneMinuteRate"],
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.CloudWatchWriter",
@@ -45,7 +45,7 @@
         {
           "obj": "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec",
           "resultAlias": "kafka-server",
-          "attr": ["Count"],
+          "attr": ["Count", "OneMinuteRate"],
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.CloudWatchWriter",


### PR DESCRIPTION
The OneMinuteRate shows the peaks for message produce/consume throughput because CloudWatch Metrics doesn't provide a way to calculate this. The Count metric shows messages produced/consumed since topic creation and shows a rising graph.